### PR TITLE
Implement legend visibility toggle and filename display

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -25,7 +25,7 @@ class MainWindow : public QMainWindow
 public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
-    void plot(const QVector<double> &x, const QVector<double> &y, const QColor &color);
+    void plot(const QVector<double> &x, const QVector<double> &y, const QColor &color, const QString &name);
     void processFiles(const QStringList &files);
 
 private slots:


### PR DESCRIPTION
This commit implements the logic for the `on_checkBoxLegend_checkStateChanged` function to toggle the visibility of the plot legend.

The `plot` function is modified to accept a name for the graph, which is then added to the legend. The `processFiles` function is updated to extract the filename from the file path and pass it to the `plot` function, so that the legend displays the filenames of the plotted files.

The legend is initially hidden, and its items are made selectable for better user experience.