### PR TITLE
feat: Implement right-button drag and double-click autoscale

### DIFF
--- a/fsnpview.pro
+++ b/fsnpview.pro
@@ -25,7 +25,6 @@ FORMS += \
     mainwindow.ui
 
 INCLUDEPATH += /usr/include/eigen3
-INCLUDEPATH += "C:\home\projekte\Qt\eigen-3.4.0"
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <QLocalServer>
 #include <QLocalSocket>
+#include <QMouseEvent>
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -28,6 +29,12 @@ public:
     void plot(const QVector<double> &x, const QVector<double> &y, const QColor &color, const QString &name);
     void processFiles(const QStringList &files);
 
+public slots:
+    void mousePress(QMouseEvent *event);
+    void mouseMove(QMouseEvent *event);
+    void mouseRelease(QMouseEvent *event);
+    void mouseDoubleClick(QMouseEvent *event);
+
 private slots:
     void on_pushButtonAutoscale_clicked();
     void newConnection();
@@ -43,5 +50,7 @@ private:
     Ui::MainWindow *ui;
     std::map<std::string, std::unique_ptr<ts::TouchstoneData>> parsed_data;
     QLocalServer *localServer;
+    bool mIsDragging;
+    QPointF mLastMousePos;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This commit introduces two new user interactions to the plot view:

1.  The plot can now be dragged by holding the right mouse button.
2.  A double-click with the left mouse button will autoscale the plot to fit the data.

The default QCustomPlot interactions were modified to disable the default drag behavior. The new interactions are implemented by handling the `mousePress`, `mouseMove`, `mouseRelease`, and `mouseDoubleClick` signals from the QCustomPlot widget.