### PR TITLE
Fix plot dragging and zooming behavior

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -15,7 +15,6 @@ MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
     , localServer(nullptr)
-    , mIsDragging(false)
 {
     ui->setupUi(this);
 
@@ -32,9 +31,6 @@ MainWindow::MainWindow(QWidget *parent)
     }
     connect(localServer, &QLocalServer::newConnection, this, &MainWindow::newConnection);
 
-    connect(ui->widgetGraph, &QCustomPlot::mousePress, this, &MainWindow::mousePress);
-    connect(ui->widgetGraph, &QCustomPlot::mouseMove, this, &MainWindow::mouseMove);
-    connect(ui->widgetGraph, &QCustomPlot::mouseRelease, this, &MainWindow::mouseRelease);
     connect(ui->widgetGraph, &QCustomPlot::mouseDoubleClick, this, &MainWindow::mouseDoubleClick);
 }
 
@@ -46,8 +42,10 @@ MainWindow::~MainWindow()
 void MainWindow::plot(const QVector<double> &x, const QVector<double> &y, const QColor &color, const QString &name)
 {
     QCustomPlot *customPlot = ui->widgetGraph;
-    customPlot->setInteractions(QCP::iRangeZoom | QCP::iSelectPlottables);
+    customPlot->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom | QCP::iSelectPlottables);
     customPlot->setSelectionRectMode(QCP::srmZoom);
+    customPlot->setRangeDragButton(Qt::RightButton);
+    customPlot->setSelectionRectButton(Qt::LeftButton);
 
     int graphCount = customPlot->graphCount();
     customPlot->addGraph();
@@ -168,39 +166,6 @@ void MainWindow::on_checkBoxLegend_checkStateChanged(const Qt::CheckState &arg1)
 {
     ui->widgetGraph->legend->setVisible(arg1 == Qt::Checked);
     ui->widgetGraph->replot();
-}
-
-void MainWindow::mousePress(QMouseEvent *event)
-{
-    if (event->button() == Qt::RightButton)
-    {
-        mIsDragging = true;
-        mLastMousePos = event->pos();
-    }
-}
-
-void MainWindow::mouseMove(QMouseEvent *event)
-{
-    if (mIsDragging)
-    {
-        double x_diff = ui->widgetGraph->xAxis->pixelToCoord(mLastMousePos.x()) - ui->widgetGraph->xAxis->pixelToCoord(event->pos().x());
-        double y_diff = ui->widgetGraph->yAxis->pixelToCoord(mLastMousePos.y()) - ui->widgetGraph->yAxis->pixelToCoord(event->pos().y());
-
-        ui->widgetGraph->xAxis->moveRange(x_diff);
-        ui->widgetGraph->yAxis->moveRange(y_diff);
-
-        mLastMousePos = event->pos();
-
-        ui->widgetGraph->replot();
-    }
-}
-
-void MainWindow::mouseRelease(QMouseEvent *event)
-{
-    if (event->button() == Qt::RightButton)
-    {
-        mIsDragging = false;
-    }
 }
 
 void MainWindow::mouseDoubleClick(QMouseEvent *event)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -30,9 +30,6 @@ public:
     void processFiles(const QStringList &files);
 
 public slots:
-    void mousePress(QMouseEvent *event);
-    void mouseMove(QMouseEvent *event);
-    void mouseRelease(QMouseEvent *event);
     void mouseDoubleClick(QMouseEvent *event);
 
 private slots:
@@ -50,7 +47,5 @@ private:
     Ui::MainWindow *ui;
     std::map<std::string, std::unique_ptr<ts::TouchstoneData>> parsed_data;
     QLocalServer *localServer;
-    bool mIsDragging;
-    QPointF mLastMousePos;
 };
 #endif // MAINWINDOW_H

--- a/qcustomplot.cpp
+++ b/qcustomplot.cpp
@@ -13625,6 +13625,8 @@ QCustomPlot::QCustomPlot(QWidget *parent) :
   mReplotQueued(false),
   mReplotTime(0),
   mReplotTimeAverage(0),
+  mRangeDragButton(Qt::LeftButton),
+  mSelectionRectButton(Qt::LeftButton),
   mOpenGlMultisamples(16),
   mOpenGlAntialiasedElementsBackup(QCP::aeNone),
   mOpenGlCacheLabelsBackup(true)
@@ -13984,7 +13986,7 @@ void QCustomPlot::setSelectionRectMode(QCP::SelectionRectMode mode)
   {
     if (mode == QCP::srmNone)
       mSelectionRect->cancel(); // when switching to none, we immediately want to abort a potentially active selection rect
-    
+
     // disconnect old connections:
     if (mSelectionRectMode == QCP::srmSelect)
       disconnect(mSelectionRect, SIGNAL(accepted(QRect,QMouseEvent*)), this, SLOT(processRectSelection(QRect,QMouseEvent*)));
@@ -13999,6 +14001,26 @@ void QCustomPlot::setSelectionRectMode(QCP::SelectionRectMode mode)
   }
   
   mSelectionRectMode = mode;
+}
+
+/*!
+  Sets the mouse button that is used to drag axis ranges.
+
+  \see setSelectionRectButton, setInteractions
+*/
+void QCustomPlot::setRangeDragButton(Qt::MouseButton button)
+{
+  mRangeDragButton = button;
+}
+
+/*!
+  Sets the mouse button that is used to create a selection rect.
+
+  \see setRangeDragButton, setSelectionRectMode
+*/
+void QCustomPlot::setSelectionRectButton(Qt::MouseButton button)
+{
+  mSelectionRectButton = button;
 }
 
 /*!
@@ -15580,7 +15602,7 @@ void QCustomPlot::mousePressEvent(QMouseEvent *event)
   mMouseHasMoved = false;
   mMousePressPos = event->pos();
   
-  if (mSelectionRect && mSelectionRectMode != QCP::srmNone)
+  if (mSelectionRect && mSelectionRectMode != QCP::srmNone && event->button() == mSelectionRectButton)
   {
     if (mSelectionRectMode != QCP::srmZoom || qobject_cast<QCPAxisRect*>(axisRectAt(mMousePressPos))) // in zoom mode only activate selection rect if on an axis rect
       mSelectionRect->startSelection(event);
@@ -18543,7 +18565,7 @@ void QCPAxisRect::layoutChanged()
 void QCPAxisRect::mousePressEvent(QMouseEvent *event, const QVariant &details)
 {
   Q_UNUSED(details)
-  if (event->buttons() & Qt::LeftButton)
+  if (event->button() == mParentPlot->rangeDragButton())
   {
     mDragging = true;
     // initialize antialiasing backup in case we start dragging:

--- a/qcustomplot.h
+++ b/qcustomplot.h
@@ -3845,8 +3845,10 @@ public:
   Qt::KeyboardModifier multiSelectModifier() const { return mMultiSelectModifier; }
   QCP::SelectionRectMode selectionRectMode() const { return mSelectionRectMode; }
   QCPSelectionRect *selectionRect() const { return mSelectionRect; }
+  Qt::MouseButton rangeDragButton() const { return mRangeDragButton; }
+  Qt::MouseButton selectionRectButton() const { return mSelectionRectButton; }
   bool openGl() const { return mOpenGl; }
-  
+
   // setters:
   void setViewport(const QRect &rect);
   void setBufferDevicePixelRatio(double ratio);
@@ -3869,8 +3871,10 @@ public:
   void setMultiSelectModifier(Qt::KeyboardModifier modifier);
   void setSelectionRectMode(QCP::SelectionRectMode mode);
   void setSelectionRect(QCPSelectionRect *selectionRect);
+  void setRangeDragButton(Qt::MouseButton button);
+  void setSelectionRectButton(Qt::MouseButton button);
   void setOpenGl(bool enabled, int multisampling=16);
-  
+
   // non-property methods:
   // plottable interface:
   QCPAbstractPlottable *plottable(int index);
@@ -3989,8 +3993,10 @@ protected:
   Qt::KeyboardModifier mMultiSelectModifier;
   QCP::SelectionRectMode mSelectionRectMode;
   QCPSelectionRect *mSelectionRect;
+  Qt::MouseButton mRangeDragButton;
+  Qt::MouseButton mSelectionRectButton;
   bool mOpenGl;
-  
+
   // non-property members:
   QList<QSharedPointer<QCPAbstractPaintBuffer> > mPaintBuffers;
   QPoint mMousePressPos;


### PR DESCRIPTION
This commit fixes the behavior of dragging and rectangle zoom in the plot. The user wanted the right mouse button to only drag the plot, and the left mouse button to only create a zoom rectangle.

To achieve this, I've made the following changes:

- Enhanced `QCustomPlot` to allow configuring the mouse buttons for range dragging and selection rectangle zooming.
- Modified the event handling in `QCustomPlot` and `QCPAxisRect` to respect the new configurable mouse buttons.
- Refactored `MainWindow` to use the new `QCustomPlot` features, removing the manual mouse handling implementation.

This results in a cleaner and more flexible implementation that correctly separates the drag and zoom interactions as requested.