### PR TITLE
Implement draggable crosshair cursors with y-value display

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -19,6 +19,9 @@ class MainWindow;
 }
 QT_END_NAMESPACE
 
+class QCPItemTracer;
+class QCPItemText;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -31,21 +34,30 @@ public:
 
 public slots:
     void mouseDoubleClick(QMouseEvent *event);
+    void mousePress(QMouseEvent *event);
+    void mouseMove(QMouseEvent *event);
+    void mouseRelease(QMouseEvent *event);
 
 private slots:
     void on_pushButtonAutoscale_clicked();
     void newConnection();
     void readyRead();
 
-    void on_checkBoxCursorA_checkStateChanged(const Qt::CheckState &arg1);
+    void on_checkBoxCursorA_stateChanged(int arg1);
 
-    void on_checkBoxCursorB_checkStateChanged(const Qt::CheckState &arg1);
+    void on_checkBoxCursorB_stateChanged(int arg1);
 
-    void on_checkBoxLegend_checkStateChanged(const Qt::CheckState &arg1);
+    void on_checkBoxLegend_stateChanged(int arg1);
 
 private:
+    void updateTracerText(QCPItemTracer *tracer, QCPItemText *text);
     Ui::MainWindow *ui;
     std::map<std::string, std::unique_ptr<ts::TouchstoneData>> parsed_data;
     QLocalServer *localServer;
+    QCPItemTracer *mTracerA;
+    QCPItemText *mTracerTextA;
+    QCPItemTracer *mTracerB;
+    QCPItemText *mTracerTextB;
+    QCPItemTracer *mDraggedTracer;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This commit introduces two draggable crosshair cursors, toggled by checkboxes "Cursor A" and "Cursor B".

- When a cursor is enabled, it appears as a crosshair on the plot.
- The cursor can be dragged by its vertical line.
- The y-value at the cursor's position is displayed in a text label next to it.
- Cursor A is red, and Cursor B is blue.

The implementation uses QCPItemTracer for the crosshair and QCPItemText for the y-value label. Mouse events on the QCustomPlot widget are handled to enable dragging.