### PR TITLE
Implement draggable crosshair cursors with y-value display

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -32,6 +32,36 @@ MainWindow::MainWindow(QWidget *parent)
     connect(localServer, &QLocalServer::newConnection, this, &MainWindow::newConnection);
 
     connect(ui->widgetGraph, &QCustomPlot::mouseDoubleClick, this, &MainWindow::mouseDoubleClick);
+    connect(ui->widgetGraph, &QCustomPlot::mousePress, this, &MainWindow::mousePress);
+    connect(ui->widgetGraph, &QCustomPlot::mouseMove, this, &MainWindow::mouseMove);
+    connect(ui->widgetGraph, &QCustomPlot::mouseRelease, this, &MainWindow::mouseRelease);
+
+    mTracerA = new QCPItemTracer(ui->widgetGraph);
+    mTracerA->setPen(QPen(Qt::red));
+    mTracerA->setBrush(Qt::NoBrush);
+    mTracerA->setStyle(QCPItemTracer::tsCrosshair);
+    mTracerA->setVisible(false);
+    mTracerA->setInterpolating(true);
+
+    mTracerTextA = new QCPItemText(ui->widgetGraph);
+    mTracerTextA->setColor(Qt::red);
+    mTracerTextA->setVisible(false);
+    mTracerTextA->setBrush(QColor(255, 255, 255, 190));
+
+
+    mTracerB = new QCPItemTracer(ui->widgetGraph);
+    mTracerB->setPen(QPen(Qt::blue));
+    mTracerB->setBrush(Qt::NoBrush);
+    mTracerB->setStyle(QCPItemTracer::tsCrosshair);
+    mTracerB->setVisible(false);
+    mTracerB->setInterpolating(true);
+
+    mTracerTextB = new QCPItemText(ui->widgetGraph);
+    mTracerTextB->setColor(Qt::blue);
+    mTracerTextB->setVisible(false);
+    mTracerTextB->setBrush(QColor(255, 255, 255, 190));
+
+    mDraggedTracer = nullptr;
 }
 
 MainWindow::~MainWindow()
@@ -116,6 +146,7 @@ void MainWindow::processFiles(const QStringList &files)
             std::cerr << "Error processing file " << files.at(i).toStdString() << ": " << e.what() << std::endl;
         }
     }
+
 }
 
 void MainWindow::on_pushButtonAutoscale_clicked()
@@ -150,15 +181,47 @@ void MainWindow::readyRead()
     }
 }
 
-void MainWindow::on_checkBoxCursorA_checkStateChanged(const Qt::CheckState &arg1)
+void MainWindow::on_checkBoxCursorA_stateChanged(int arg1)
 {
+    if (ui->widgetGraph->graphCount() == 0)
+    {
+        ui->checkBoxCursorA->setCheckState(Qt::Unchecked);
+        return;
+    }
 
+    mTracerA->setVisible(arg1 == Qt::Checked);
+    mTracerTextA->setVisible(arg1 == Qt::Checked);
+
+    if (arg1 == Qt::Checked)
+    {
+        QCPGraph *graph = ui->widgetGraph->graph(0);
+        mTracerA->setGraph(graph);
+        mTracerA->setGraphKey(ui->widgetGraph->xAxis->range().center());
+        updateTracerText(mTracerA, mTracerTextA);
+    }
+    ui->widgetGraph->replot();
 }
 
 
-void MainWindow::on_checkBoxCursorB_checkStateChanged(const Qt::CheckState &arg1)
+void MainWindow::on_checkBoxCursorB_stateChanged(int arg1)
 {
+    if (ui->widgetGraph->graphCount() == 0)
+    {
+        ui->checkBoxCursorB->setCheckState(Qt::Unchecked);
+        return;
+    }
 
+    mTracerB->setVisible(arg1 == Qt::Checked);
+    mTracerTextB->setVisible(arg1 == Qt::Checked);
+
+    if (arg1 == Qt::Checked)
+    {
+        QCPGraph *graph = ui->widgetGraph->graph(0);
+        mTracerB->setGraph(graph);
+        mTracerB->setGraphKey(ui->widgetGraph->xAxis->range().center());
+        updateTracerText(mTracerB, mTracerTextB);
+    }
+    ui->widgetGraph->replot();
 }
 
 
@@ -175,4 +238,78 @@ void MainWindow::mouseDoubleClick(QMouseEvent *event)
         ui->widgetGraph->rescaleAxes();
         ui->widgetGraph->replot();
     }
+}
+
+void MainWindow::mousePress(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton)
+    {
+        QCPItemTracer* tracer = nullptr;
+        if (mTracerA->visible())
+        {
+            double x_px = mTracerA->position->pixelPosition().x();
+            if (qAbs(event->pos().x() - x_px) < 5) // 5px tolerance
+            {
+                tracer = mTracerA;
+            }
+        }
+        if (!tracer && mTracerB->visible())
+        {
+            double x_px = mTracerB->position->pixelPosition().x();
+            if (qAbs(event->pos().x() - x_px) < 5) // 5px tolerance
+            {
+                tracer = mTracerB;
+            }
+        }
+
+        if (tracer)
+        {
+            mDraggedTracer = tracer;
+            ui->widgetGraph->setSelectionRectMode(QCP::srmNone);
+        }
+    }
+}
+
+void MainWindow::mouseMove(QMouseEvent *event)
+{
+    if (mDraggedTracer)
+    {
+        double key = ui->widgetGraph->xAxis->pixelToCoord(event->pos().x());
+        mDraggedTracer->setGraphKey(key);
+
+        if (mDraggedTracer == mTracerA)
+            updateTracerText(mTracerA, mTracerTextA);
+        else if (mDraggedTracer == mTracerB)
+            updateTracerText(mTracerB, mTracerTextB);
+
+        ui->widgetGraph->replot();
+    }
+}
+
+void MainWindow::mouseRelease(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton)
+    {
+        if (mDraggedTracer)
+        {
+            mDraggedTracer = nullptr;
+            ui->widgetGraph->setSelectionRectMode(QCP::srmZoom);
+        }
+    }
+}
+
+void MainWindow::updateTracerText(QCPItemTracer *tracer, QCPItemText *text)
+{
+    if (!tracer->visible() || !tracer->graph())
+        return;
+
+    tracer->updatePosition();
+    double key = tracer->position->coords().x();
+    double value = tracer->position->coords().y();
+
+    text->setText(QString::number(value, 'f', 2));
+    text->position->setCoords(key, value);
+    text->position->setType(QCPItemPosition::ptPlotCoords);
+    text->setPositionAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    text->setPadding(QMargins(5, 0, 0, 0));
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -19,6 +19,9 @@ class MainWindow;
 }
 QT_END_NAMESPACE
 
+class QCPItemTracer;
+class QCPItemText;
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -31,21 +34,30 @@ public:
 
 public slots:
     void mouseDoubleClick(QMouseEvent *event);
+    void mousePress(QMouseEvent *event);
+    void mouseMove(QMouseEvent *event);
+    void mouseRelease(QMouseEvent *event);
 
 private slots:
     void on_pushButtonAutoscale_clicked();
     void newConnection();
     void readyRead();
 
-    void on_checkBoxCursorA_checkStateChanged(const Qt::CheckState &arg1);
+    void on_checkBoxCursorA_stateChanged(int arg1);
 
-    void on_checkBoxCursorB_checkStateChanged(const Qt::CheckState &arg1);
+    void on_checkBoxCursorB_stateChanged(int arg1);
 
     void on_checkBoxLegend_checkStateChanged(const Qt::CheckState &arg1);
 
 private:
+    void updateTracerText(QCPItemTracer *tracer, QCPItemText *text);
     Ui::MainWindow *ui;
     std::map<std::string, std::unique_ptr<ts::TouchstoneData>> parsed_data;
     QLocalServer *localServer;
+    QCPItemTracer *mTracerA;
+    QCPItemText *mTracerTextA;
+    QCPItemTracer *mTracerB;
+    QCPItemText *mTracerTextB;
+    QCPItemTracer *mDraggedTracer;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This commit introduces two draggable crosshair cursors, toggled by checkboxes "Cursor A" and "Cursor B".

- When a cursor is enabled, it appears as a crosshair on the plot.
- The cursor can be dragged by its vertical line.
- The y-value at the cursor's position is displayed in a text label next to it.
- Cursor A is red, and Cursor B is blue.
- Rectangle zoom is disabled while dragging a cursor to prevent conflicts.

The implementation uses QCPItemTracer for the crosshair and QCPItemText for the y-value label. Mouse events on the QCustomPlot widget are handled to enable dragging.