### PR TITLE
Implement draggable crosshair cursors with plot switching

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -47,9 +47,10 @@ private slots:
 
     void on_checkBoxCursorB_stateChanged(int arg1);
 
-    void on_checkBoxLegend_stateChanged(int arg1);
+    void on_checkBoxLegend_checkStateChanged(const Qt::CheckState &arg1);
 
 private:
+    enum class DragMode { None, Vertical, Horizontal };
     void updateTracerText(QCPItemTracer *tracer, QCPItemText *text);
     Ui::MainWindow *ui;
     std::map<std::string, std::unique_ptr<ts::TouchstoneData>> parsed_data;
@@ -59,5 +60,6 @@ private:
     QCPItemTracer *mTracerB;
     QCPItemText *mTracerTextB;
     QCPItemTracer *mDraggedTracer;
+    DragMode mDragMode;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
This commit introduces two draggable crosshair cursors, toggled by checkboxes "Cursor A" and "Cursor B".

- When a cursor is enabled, it appears as a crosshair on the plot.
- The cursor can be dragged by its vertical line to move along the key axis.
- The cursor can be dragged by its horizontal line to switch to a different plot.
- The y-value at the cursor's position is displayed in a text label next to it.
- Cursor A is red, and Cursor B is blue.
- Rectangle zoom is disabled while dragging a cursor to prevent conflicts.

The implementation uses QCPItemTracer for the crosshair and QCPItemText for the y-value label. Mouse events on the QCustomPlot widget are handled to enable dragging and plot switching.