### PR TITLE
Fix plot interactions and add math plot feature

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -239,6 +239,15 @@ void MainWindow::on_checkBoxS11_checkStateChanged(const Qt::CheckState &arg1)
     updatePlots();
 }
 
+void MainWindow::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Minus)
+    {
+        m_plot_manager->createMathPlot();
+    }
+    QMainWindow::keyPressEvent(event);
+}
+
 void MainWindow::on_checkBoxS21_checkStateChanged(const Qt::CheckState &arg1)
 {
     Q_UNUSED(arg1);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -53,6 +53,8 @@ private slots:
     void onNetworkCascadeModelChanged(QStandardItem *item);
     void onNetworkDropped(Network* network, const QModelIndex& parent);
 
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
 
 private:
     void updatePlots();

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -30,12 +30,14 @@ public slots:
     void mouseRelease(QMouseEvent *event);
     void setCursorAVisible(bool visible);
     void setCursorBVisible(bool visible);
+    void createMathPlot();
 
 private:
     enum class DragMode { None, Vertical, Horizontal };
     void plot(const QVector<double> &x, const QVector<double> &y, const QColor &color, const QString &name, const QString &yAxisLabel, Qt::PenStyle style = Qt::SolidLine);
     void updateTracerText(QCPItemTracer *tracer, QCPItemText *text);
     void updateTracers();
+    void checkForTracerDrag(QMouseEvent *event, QCPItemTracer *tracer);
 
 
     QCustomPlot* m_plot;


### PR DESCRIPTION
This commit addresses several issues with the plot interactions and adds a new feature to create a "math plot".

The following changes were made:

- Panning is now done with the right mouse button, as requested.
- Tracer dragging is done with the left mouse button. Dragging the vertical line of the tracer moves it within the same plot, while dragging the horizontal line allows moving it to other plots.
- Tracers are now rendered on top of the plots, ensuring they are always visible.
- A new "math plot" feature has been added. When two plots are selected and the '-' key is pressed, a new plot is created that displays the difference between the values of the two selected plots. The new plot is colored red.