### PR TITLE
Fix QCustomPlot 2.x item registration

### DIFF
--- a/SmithChartGrid.h
+++ b/SmithChartGrid.h
@@ -9,15 +9,15 @@ namespace SmithChart
 {
 
 // ---- Version-compat helper -----------------------------------------------
-// QCustomPlot < 2.0: items auto-register via constructor, no addItem() API.
-// QCustomPlot ≥ 2.0: must call plot->addItem(item).
+// QCustomPlot < 2.0: must call plot->addItem(item).
+// QCustomPlot ≥ 2.0: items auto-register via constructor, no addItem() API.
 #ifndef QCUSTOMPLOT_VERSION
 #define QCUSTOMPLOT_VERSION 0
 #endif
 
 inline void addItemCompat(QCustomPlot* plot, QCPAbstractItem* item)
 {
-#if QCUSTOMPLOT_VERSION >= 0x020000
+#if QCUSTOMPLOT_VERSION < 0x020000
     plot->addItem(item);
 #else
     Q_UNUSED(plot);


### PR DESCRIPTION
## Summary
- Correct version check for QCustomPlot item registration to avoid calling removed `addItem()` method on 2.x

## Testing
- `qmake6`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68c48449315c83269c7862e65eeaae2a