### PR TITLE
Handle deletions of selected plots and avoid crashes

### DIFF
--- a/plotmanager.h
+++ b/plotmanager.h
@@ -34,7 +34,9 @@ public slots:
 
 private:
     enum class DragMode { None, Vertical, Horizontal };
-    void plot(const QVector<double> &x, const QVector<double> &y, const QColor &color, const QString &name, Qt::PenStyle style = Qt::SolidLine);
+    void plot(const QVector<double> &x, const QVector<double> &y, const QColor &color,
+              const QString &name, Network* network,
+              Qt::PenStyle style = Qt::SolidLine);
     void updateTracerText(QCPItemTracer *tracer, QCPItemText *text);
     void updateTracers();
     void checkForTracerDrag(QMouseEvent *event, QCPItemTracer *tracer);


### PR DESCRIPTION
## Summary
- Allow deleting plots selected in the graph
- Remove file networks and hide lumped networks when pressing Delete
- Track network pointers on graphs to relate selections back to models

## Testing
- `qmake6`
- `make -j$(nproc)`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c48961fd448326ad7e841f44325417