### PR TITLE
Add color selection column for network lists

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -57,6 +57,7 @@ private slots:
     void onNetworkFilesSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void onNetworkLumpedSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void onNetworkCascadeSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
+    void onColorColumnClicked(const QModelIndex &index);
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;

--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -73,6 +73,13 @@ void PlotManager::setCascade(NetworkCascade* cascade)
     m_cascade = cascade;
 }
 
+QColor PlotManager::nextColor()
+{
+    QColor color = m_colors.at(m_color_index % m_colors.size());
+    m_color_index++;
+    return color;
+}
+
 void PlotManager::plot(const QVector<double> &x, const QVector<double> &y, const QColor &color,
                        const QString &name, Network* network,
                        Qt::PenStyle style)
@@ -120,7 +127,6 @@ void PlotManager::updatePlots(const QStringList& sparams, bool isPhase)
         }
     }
 
-    m_color_index = 0;
     // Add new graphs
     for (const auto& sparam : sparams) {
         int sparam_idx_to_plot = -1;
@@ -138,15 +144,15 @@ void PlotManager::updatePlots(const QStringList& sparams, bool isPhase)
                 for(int i=0; i<m_plot->graphCount(); ++i) {
                     if(m_plot->graph(i)->name() == graph_name) {
                         graph_exists = true;
+                        m_plot->graph(i)->setPen(QPen(network->color(), 0, Qt::SolidLine));
                         break;
                     }
                 }
                 if (!graph_exists) {
                     auto plotData = network->getPlotData(sparam_idx_to_plot, isPhase);
                     plot(plotData.first, plotData.second,
-                         m_colors.at(m_color_index % m_colors.size()),
+                         network->color(),
                          graph_name, network);
-                    m_color_index++;
                 }
             }
         }

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -22,6 +22,7 @@ public:
     void setCascade(NetworkCascade* cascade);
     void updatePlots(const QStringList& sparams, bool isPhase);
     void autoscale();
+    QColor nextColor();
 
 public slots:
     void mouseDoubleClick(QMouseEvent *event);


### PR DESCRIPTION
## Summary
- Add `Color` column to file, lumped, and cascade network tables
- Allow users to pick plot colors via QColorDialog
- PlotManager exposes `nextColor` and uses each network's color when drawing graphs

## Testing
- `qmake6`
- `make -j$(nproc)`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c49bacd2248326a7cb1c5d0a6121ca