### PR TITLE
Update cascade plotting and enable cascade reordering

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -52,7 +52,7 @@ private slots:
     void onNetworkFilesModelChanged(QStandardItem *item);
     void onNetworkLumpedModelChanged(QStandardItem *item);
     void onNetworkCascadeModelChanged(QStandardItem *item);
-    void onNetworkDropped(Network* network, const QModelIndex& parent);
+    void onNetworkDropped(Network* network, int row, const QModelIndex& parent);
     void onGraphSelectionChanged();
     void onNetworkFilesSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void onNetworkLumpedSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);

--- a/networkcascade.cpp
+++ b/networkcascade.cpp
@@ -9,7 +9,24 @@ NetworkCascade::NetworkCascade(QObject *parent) : Network(parent)
 
 void NetworkCascade::addNetwork(Network* network)
 {
-    m_networks.append(network);
+    insertNetwork(m_networks.size(), network);
+}
+
+void NetworkCascade::insertNetwork(int index, Network* network)
+{
+    if (index < 0 || index > m_networks.size())
+        index = m_networks.size();
+    m_networks.insert(index, network);
+    updateFrequencyRange();
+}
+
+void NetworkCascade::moveNetwork(int from, int to)
+{
+    if (from < 0 || from >= m_networks.size() || to < 0 || to >= m_networks.size())
+        return;
+    if (from == to)
+        return;
+    m_networks.insert(to, m_networks.takeAt(from));
     updateFrequencyRange();
 }
 

--- a/networkcascade.h
+++ b/networkcascade.h
@@ -12,6 +12,8 @@ public:
     explicit NetworkCascade(QObject *parent = nullptr);
 
     void addNetwork(Network* network);
+    void insertNetwork(int index, Network* network);
+    void moveNetwork(int from, int to);
     void removeNetwork(int index);
     void clearNetworks();
     const QList<Network*>& getNetworks() const;

--- a/networkitemmodel.cpp
+++ b/networkitemmodel.cpp
@@ -69,9 +69,14 @@ bool NetworkItemModel::dropMimeData(const QMimeData *data, Qt::DropAction action
         stream >> network_ptr_val;
         Network *network = reinterpret_cast<Network*>(network_ptr_val);
         if (network) {
-            emit networkDropped(network, parent);
+            emit networkDropped(network, row, parent);
         }
     }
 
     return true;
+}
+
+Qt::DropActions NetworkItemModel::supportedDropActions() const
+{
+    return Qt::CopyAction | Qt::MoveAction;
 }

--- a/networkitemmodel.h
+++ b/networkitemmodel.h
@@ -17,9 +17,10 @@ public:
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
+    Qt::DropActions supportedDropActions() const override;
 
 signals:
-    void networkDropped(Network* network, const QModelIndex& parent);
+    void networkDropped(Network* network, int row, const QModelIndex& parent);
 };
 
 #endif // NETWORKITEMMODEL_H

--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -161,15 +161,20 @@ void PlotManager::updatePlots(const QStringList& sparams, bool isPhase)
         if (m_cascade && m_cascade->getNetworks().size() > 0) {
             QString graph_name = m_cascade->name() + "_" + sparam;
             if (isPhase) graph_name += "_phase";
-             bool graph_exists = false;
-            for(int i=0; i<m_plot->graphCount(); ++i) {
-                if(m_plot->graph(i)->name() == graph_name) {
-                    graph_exists = true;
+
+            QCPGraph *graph = nullptr;
+            for (int i = 0; i < m_plot->graphCount(); ++i) {
+                if (m_plot->graph(i)->name() == graph_name) {
+                    graph = m_plot->graph(i);
                     break;
                 }
             }
-            if(!graph_exists) {
-                auto plotData = m_cascade->getPlotData(sparam_idx_to_plot, isPhase);
+
+            auto plotData = m_cascade->getPlotData(sparam_idx_to_plot, isPhase);
+
+            if (graph) {
+                graph->setData(plotData.first, plotData.second);
+            } else {
                 plot(plotData.first, plotData.second, Qt::black,
                      graph_name, nullptr, Qt::DashLine);
             }


### PR DESCRIPTION
## Summary
- Refresh cascade plot data whenever the network list changes
- Allow dragging networks within the cascade table to reorder and recalc the cascade instantly

## Testing
- `qmake6`
- `make -j$(nproc)`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c49fb75a0483268a3cbd3185fb8137