### PR TITLE
Fix graph selection slot signature

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -44,7 +44,7 @@ MainWindow::MainWindow(QWidget *parent)
     m_plot_manager->setCascade(m_cascade);
 
     connect(ui->widgetGraph, &QCustomPlot::selectionChangedByUser,
-            this, &MainWindow::onGraphSelectionChanged);
+            this, &MainWindow::onGraphSelectionChangedByUser);
     connect(ui->tableViewNetworkFiles->selectionModel(), &QItemSelectionModel::selectionChanged,
             this, &MainWindow::onNetworkFilesSelectionChanged);
     connect(ui->tableViewNetworkLumped->selectionModel(), &QItemSelectionModel::selectionChanged,
@@ -298,7 +298,7 @@ void MainWindow::onNetworkCascadeModelChanged(QStandardItem *item)
     }
 }
 
-void MainWindow::onGraphSelectionChanged()
+void MainWindow::onGraphSelectionChangedByUser()
 {
     QSet<Network*> selectedNetworks;
     const auto graphs = ui->widgetGraph->selectedGraphs();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -57,6 +57,7 @@ private slots:
 
     void onNetworkDropped(Network* network, int row, const QModelIndex& parent);
     void onGraphSelectionChanged(QCPAbstractPlottable *plottable, int dataIndex, QMouseEvent *event);
+    void onGraphSelectionChangedByUser();
     void onNetworkFilesSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void onNetworkLumpedSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void onNetworkCascadeSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);


### PR DESCRIPTION
## Summary
- ensure graph selection slot signature matches signal
- add dedicated handler for user selection changes

## Testing
- `qmake6`
- `make -j2`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5c255e60c8326a2416ccf4e55c709