### PR TITLE
Add NetworkCascade unit test

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
-# This script builds the parser tests.
+# This script builds the parser and network cascade tests.
 set -e
+
 g++ -std=c++17 -I/usr/include/eigen3 -I. tests/parser_touchstone_tests.cpp parser_touchstone.cpp -o parser_touchstone_tests
+
+/usr/lib/qt6/libexec/moc network.h -o /tmp/moc_network.cpp
+/usr/lib/qt6/libexec/moc networkfile.h -o /tmp/moc_networkfile.cpp
+/usr/lib/qt6/libexec/moc networkcascade.h -o /tmp/moc_networkcascade.cpp
+
+g++ -std=c++17 -I/usr/include/eigen3 -I. tests/networkcascade_tests.cpp parser_touchstone.cpp network.cpp networkfile.cpp networkcascade.cpp /tmp/moc_network.cpp /tmp/moc_networkfile.cpp /tmp/moc_networkcascade.cpp $(pkg-config --cflags --libs Qt6Core Qt6Gui) -o networkcascade_tests

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# Run parser touchstone tests.
+# Run parser and network cascade tests.
 set -e
 ./parser_touchstone_tests
+./networkcascade_tests

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -1,0 +1,49 @@
+#include "networkcascade.h"
+#include "networkfile.h"
+#include <Eigen/Dense>
+#include <cassert>
+#include <complex>
+#include <iostream>
+
+void test_cascade_two_files()
+{
+    NetworkFile net1(QStringLiteral("test/a (1).s2p"));
+    NetworkFile net2(QStringLiteral("test/a (2).s2p"));
+
+    NetworkCascade cascade;
+    cascade.addNetwork(&net1);
+    cascade.addNetwork(&net2);
+
+    Eigen::VectorXd freq(1);
+    freq << 40e6; // 40 MHz
+
+    Eigen::MatrixXcd abcd_matrix = cascade.abcd(freq);
+    Eigen::Matrix2cd abcd;
+    abcd << abcd_matrix(0, 0), abcd_matrix(0, 1),
+             abcd_matrix(0, 2), abcd_matrix(0, 3);
+
+    Eigen::Vector4cd s = Network::abcd2s(abcd);
+
+    std::complex<double> s11_expected(0.014920405958677847, 0.01630490315700499);
+    std::complex<double> s12_expected(0.9574040676271609, -0.20781677254865813);
+    std::complex<double> s21_expected(0.959119351068381, -0.2029186101162592);
+    std::complex<double> s22_expected(0.01709181671098506, 0.014520122008960062);
+
+    auto close = [](std::complex<double> a, std::complex<double> b) {
+        return std::abs(a.real() - b.real()) < 1e-6 &&
+               std::abs(a.imag() - b.imag()) < 1e-6;
+    };
+
+    assert(close(s[0], s11_expected));
+    assert(close(s[1], s12_expected));
+    assert(close(s[2], s21_expected));
+    assert(close(s[3], s22_expected));
+}
+
+int main()
+{
+    test_cascade_two_files();
+    std::cout << "All NetworkCascade tests passed." << std::endl;
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add unit test validating NetworkCascade against precomputed S-parameters
- build and run the new test in CI scripts

## Testing
- `./build.sh`
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c5c27004c483269feca08d56a4a9a7