### PR TITLE
Use log ticker when enabling logarithmic x-axis

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -435,8 +435,13 @@ void MainWindow::on_checkBox_checkStateChanged(const Qt::CheckState &arg1)
 {
     if (arg1 == Qt::Checked) {
         ui->widgetGraph->xAxis->setScaleType(QCPAxis::stLogarithmic);
+        QSharedPointer<QCPAxisTickerLog> logTicker(new QCPAxisTickerLog);
+        logTicker->setSubTickCount(8);
+        logTicker->setLogBase(10);
+        ui->widgetGraph->xAxis->setTicker(logTicker);
     } else {
         ui->widgetGraph->xAxis->setScaleType(QCPAxis::stLinear);
+        ui->widgetGraph->xAxis->setTicker(QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
     }
     ui->widgetGraph->replot();
 }


### PR DESCRIPTION
## Summary
- configure QCustomPlot x-axis to use `QCPAxisTickerLog` when the logarithmic scale is enabled
- restore default ticker on linear scale for consistent axis grid

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5dc1b436c8326be9f4d205fb2db90