### PR TITLE
Allow duplicate networks in cascade and improve drag-drop

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -116,6 +116,8 @@ void MainWindow::setupViews()
     ui->tableViewCascade->setDefaultDropAction(Qt::MoveAction);
     ui->tableViewCascade->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->tableViewCascade->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->tableViewCascade->setDropIndicatorShown(true);
+    ui->tableViewCascade->setStyleSheet("QTableView::item:drop-indicator { border-top: 2px solid #0000ff; border-bottom: 2px solid #0000ff; }");
     setupTableColumns(ui->tableViewCascade);
 }
 
@@ -203,19 +205,20 @@ void MainWindow::onNetworkDropped(Network* network, int row, const QModelIndex& 
             m_network_cascade_model->insertRow(row, items);
         }
     } else {
-        m_cascade->insertNetwork(row, network);
+        Network* cloned = network->clone(m_cascade);
+        m_cascade->insertNetwork(row, cloned);
 
         QList<QStandardItem*> items;
         QStandardItem* checkItem = new QStandardItem();
         checkItem->setCheckable(true);
         checkItem->setCheckState(Qt::Checked);
-        checkItem->setData(QVariant::fromValue(reinterpret_cast<quintptr>(network)), Qt::UserRole);
+        checkItem->setData(QVariant::fromValue(reinterpret_cast<quintptr>(cloned)), Qt::UserRole);
         items.append(checkItem);
         QStandardItem* colorItem = new QStandardItem();
         colorItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-        colorItem->setBackground(network->color());
+        colorItem->setBackground(cloned->color());
         items.append(colorItem);
-        items.append(new QStandardItem(network->name()));
+        items.append(new QStandardItem(cloned->name()));
         m_network_cascade_model->insertRow(row, items);
     }
 

--- a/network.h
+++ b/network.h
@@ -24,6 +24,7 @@ public:
     virtual QString name() const = 0;
     virtual Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const = 0;
     virtual QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) = 0;
+    virtual Network* clone(QObject* parent = nullptr) const = 0;
 
     double fmin() const;
     void setFmin(double fmin);

--- a/networkcascade.cpp
+++ b/networkcascade.cpp
@@ -7,6 +7,15 @@ NetworkCascade::NetworkCascade(QObject *parent) : Network(parent)
     m_fmax = 10e9;
 }
 
+NetworkCascade::~NetworkCascade()
+{
+    for (auto net : m_networks) {
+        if (net->parent() == this) {
+            net->setParent(nullptr);
+        }
+    }
+}
+
 void NetworkCascade::addNetwork(Network* network)
 {
     insertNetwork(m_networks.size(), network);
@@ -151,4 +160,19 @@ QPair<QVector<double>, QVector<double>> NetworkCascade::getPlotData(int s_param_
     }
 
     return qMakePair(xValues, yValues);
+}
+
+Network* NetworkCascade::clone(QObject* parent) const
+{
+    NetworkCascade* copy = new NetworkCascade(parent);
+    copy->setColor(m_color);
+    copy->setVisible(m_is_visible);
+    copy->setUnwrapPhase(m_unwrap_phase);
+    copy->setActive(m_is_active);
+    copy->setFmin(m_fmin);
+    copy->setFmax(m_fmax);
+    for (const auto& net : m_networks) {
+        copy->addNetwork(net->clone(copy));
+    }
+    return copy;
 }

--- a/networkcascade.h
+++ b/networkcascade.h
@@ -10,6 +10,7 @@ class NetworkCascade : public Network
     Q_OBJECT
 public:
     explicit NetworkCascade(QObject *parent = nullptr);
+    ~NetworkCascade();
 
     void addNetwork(Network* network);
     void insertNetwork(int index, Network* network);
@@ -21,6 +22,7 @@ public:
     QString name() const override;
     Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const override;
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override;
+    Network* clone(QObject* parent = nullptr) const override;
 
 private:
     void updateFrequencyRange();

--- a/networkfile.cpp
+++ b/networkfile.cpp
@@ -28,6 +28,18 @@ QString NetworkFile::filePath() const
     return m_file_path;
 }
 
+Network* NetworkFile::clone(QObject* parent) const
+{
+    NetworkFile* copy = new NetworkFile(m_file_path, parent);
+    copy->setColor(m_color);
+    copy->setVisible(m_is_visible);
+    copy->setUnwrapPhase(m_unwrap_phase);
+    copy->setActive(m_is_active);
+    copy->setFmin(m_fmin);
+    copy->setFmax(m_fmax);
+    return copy;
+}
+
 QPair<QVector<double>, QVector<double>> NetworkFile::getPlotData(int s_param_idx, PlotType type)
 {
     if (!m_data || s_param_idx < 0 || s_param_idx >= m_data->sparams.cols()) {

--- a/networkfile.h
+++ b/networkfile.h
@@ -14,6 +14,7 @@ public:
     QString name() const override;
     Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const override;
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override;
+    Network* clone(QObject* parent = nullptr) const override;
 
     QString filePath() const;
 

--- a/networkitemmodel.cpp
+++ b/networkitemmodel.cpp
@@ -61,6 +61,15 @@ bool NetworkItemModel::dropMimeData(const QMimeData *data, Qt::DropAction action
         return true;
     }
 
+    int insertRow = row;
+    if (insertRow == -1) {
+        if (parent.isValid()) {
+            insertRow = parent.row();
+        } else {
+            insertRow = rowCount();
+        }
+    }
+
     QByteArray encodedData = data->data("application/vnd.fsnpview.network");
     QDataStream stream(&encodedData, QIODevice::ReadOnly);
 
@@ -69,7 +78,8 @@ bool NetworkItemModel::dropMimeData(const QMimeData *data, Qt::DropAction action
         stream >> network_ptr_val;
         Network *network = reinterpret_cast<Network*>(network_ptr_val);
         if (network) {
-            emit networkDropped(network, row, parent);
+            emit networkDropped(network, insertRow, parent);
+            ++insertRow;
         }
     }
 

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -9,6 +9,18 @@ NetworkLumped::NetworkLumped(NetworkType type, double value, QObject *parent)
     m_is_visible = false;
 }
 
+Network* NetworkLumped::clone(QObject* parent) const
+{
+    NetworkLumped* copy = new NetworkLumped(m_type, m_value, parent);
+    copy->setColor(m_color);
+    copy->setVisible(m_is_visible);
+    copy->setUnwrapPhase(m_unwrap_phase);
+    copy->setActive(m_is_active);
+    copy->setFmin(m_fmin);
+    copy->setFmax(m_fmax);
+    return copy;
+}
+
 QString NetworkLumped::name() const
 {
     QString name;

--- a/networklumped.h
+++ b/networklumped.h
@@ -21,6 +21,7 @@ public:
     QString name() const override;
     Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const override;
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override;
+    Network* clone(QObject* parent = nullptr) const override;
 
 private:
     NetworkType m_type;


### PR DESCRIPTION
## Summary
- Add cloning support for networks so dragging the same item into a cascade creates an independent copy
- Allow drop targets anywhere in the cascade list and highlight the insertion point
- Unparent cascade children on destruction to prevent unintended deletes

## Testing
- `./parser_touchstone_tests`
- ⚠️ `QT_QPA_PLATFORM=offscreen ./gui_plot_tests` (compilation hung)
- ❌ `./networkcascade_tests` (munmap_chunk(): invalid pointer)


------
https://chatgpt.com/codex/tasks/task_e_68c724a5f91083269826b3c7f483547c