### PR TITLE
Format table and legend values in engineering notation

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -162,7 +162,7 @@ void MainWindow::populateLumpedNetworkTable()
             nameItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             row.append(nameItem);
             NetworkLumped* lumped = static_cast<NetworkLumped*>(network_ptr);
-            QStandardItem* valueItem = new QStandardItem(QString::number(lumped->value()));
+            QStandardItem* valueItem = new QStandardItem(Network::formatEngineering(lumped->value()));
             row.append(valueItem);
             m_network_lumped_model->appendRow(row);
         }
@@ -234,7 +234,7 @@ void MainWindow::onNetworkDropped(Network* network, int row, const QModelIndex& 
 
         QStandardItem* valueItem = new QStandardItem();
         if (auto lumped = dynamic_cast<NetworkLumped*>(cloned)) {
-            valueItem->setText(QString::number(lumped->value()));
+            valueItem->setText(Network::formatEngineering(lumped->value()));
         } else {
             valueItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         }
@@ -325,6 +325,10 @@ void MainWindow::onNetworkLumpedModelChanged(QStandardItem *item)
                 m_network_lumped_model->item(item->row(), 2)->setText(network->name());
                 updatePlots();
             }
+            {
+                QSignalBlocker blocker(m_network_lumped_model);
+                item->setText(Network::formatEngineering(network->value()));
+            }
         }
     }
 }
@@ -348,6 +352,10 @@ void MainWindow::onNetworkCascadeModelChanged(QStandardItem *item)
                 network->setValue(val);
                 m_network_cascade_model->item(item->row(), 2)->setText(network->name());
                 updatePlots();
+            }
+            {
+                QSignalBlocker blocker(m_network_cascade_model);
+                item->setText(Network::formatEngineering(network->value()));
             }
         }
     }
@@ -674,7 +682,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
                     val *= 1.25;
                 else if (wheelEvent->angleDelta().y() < 0)
                     val *= 0.8;
-                valueItem->setText(QString::number(val));
+                valueItem->setText(Network::formatEngineering(val));
             }
             return true;
         };

--- a/network.h
+++ b/network.h
@@ -20,6 +20,7 @@ public:
 
     static Eigen::Matrix2cd s2abcd(const std::complex<double>& s11, const std::complex<double>& s12, const std::complex<double>& s21, const std::complex<double>& s22, double z0 = 50.0);
     static Eigen::Vector4cd abcd2s(const Eigen::Matrix2cd& abcd, double z0 = 50.0);
+    static QString formatEngineering(double value);
 
     virtual QString name() const = 0;
     virtual Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const = 0;

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -32,7 +32,7 @@ QString NetworkLumped::name() const
     case NetworkType::L_series: name = "L_series"; break;
     case NetworkType::L_shunt:  name = "L_shunt";  break;
     }
-    return name + "_" + QString::number(m_value);
+    return name + "_" + Network::formatEngineering(m_value);
 }
 
 Eigen::MatrixXcd NetworkLumped::abcd(const Eigen::VectorXd& freq) const


### PR DESCRIPTION
## Summary
- add a reusable Network::formatEngineering helper for fixed-width engineering notation values
- apply the helper when populating and editing lumped element tables and cascade entries
- format lumped element names with engineering notation so the legend mirrors the table values

## Testing
- ./test.sh *(fails: Qt6Widgets and related Qt6 development packages are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8734f2aa48326a826a747abf87b47