### PR TITLE
Make table selections bold without background color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This project requires a C++ compiler, Qt6 development tools, and the Eigen3 libr
 On a Debian-based system (like Ubuntu), you can install these dependencies using the following command:
 
 ```bash
-sudo apt-get update && sudo apt-get install -y build-essential qt6-base-dev libeigen3-dev
+sudo apt-get update && sudo apt-get install -y build-essential qt6-base-dev qt6-base-dev-tools libeigen3-dev
 ```
 
 ## 2. Building the Application

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # This script builds the test binaries.
-set -e
+set -euo pipefail
+set -x
 
 MOC=/usr/lib/qt6/libexec/moc
 MOC_INCLUDES="$(pkg-config --cflags Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)"

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -19,6 +19,29 @@
 #include <QVariant>
 #include <QHeaderView>
 #include <QWheelEvent>
+#include <QStyledItemDelegate>
+#include <QFont>
+#include <QStyle>
+
+namespace {
+
+class SelectionBoldDelegate : public QStyledItemDelegate
+{
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+protected:
+    void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override
+    {
+        QStyledItemDelegate::initStyleOption(option, index);
+        if (option->state.testFlag(QStyle::State_Selected)) {
+            option->state.setFlag(QStyle::State_Selected, false);
+            option->font.setBold(true);
+        }
+    }
+};
+
+} // namespace
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -103,12 +126,14 @@ void MainWindow::setupViews()
     ui->tableViewNetworkFiles->setDragDropMode(QAbstractItemView::DragOnly);
     ui->tableViewNetworkFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->tableViewNetworkFiles->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->tableViewNetworkFiles->setItemDelegate(new SelectionBoldDelegate(ui->tableViewNetworkFiles));
     setupTableColumns(ui->tableViewNetworkFiles);
 
     ui->tableViewNetworkLumped->setModel(m_network_lumped_model);
     ui->tableViewNetworkLumped->setDragDropMode(QAbstractItemView::DragOnly);
     ui->tableViewNetworkLumped->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->tableViewNetworkLumped->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->tableViewNetworkLumped->setItemDelegate(new SelectionBoldDelegate(ui->tableViewNetworkLumped));
     setupTableColumns(ui->tableViewNetworkLumped);
 
 
@@ -121,6 +146,7 @@ void MainWindow::setupViews()
     ui->tableViewCascade->setSelectionBehavior(QAbstractItemView::SelectRows);
     ui->tableViewCascade->setDropIndicatorShown(true);
     ui->tableViewCascade->setStyleSheet("QTableView::item:drop-indicator { border-top: 2px solid #0000ff; border-bottom: 2px solid #0000ff; }");
+    ui->tableViewCascade->setItemDelegate(new SelectionBoldDelegate(ui->tableViewCascade));
     setupTableColumns(ui->tableViewCascade);
 }
 


### PR DESCRIPTION
## Summary
- add a shared QStyledItemDelegate that removes the selection background while bolding text
- apply the delegate to each table view so selected rows keep their background colors
- document required Qt6 dev packages in AGENTS instructions
- make build.sh fail-fast and echo each command so build progress is visible

## Testing
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c878a7a52883268cc6508ceffb1240