### PR TITLE
Restore crosshair cursors and refine Smith chart dragging

### DIFF
--- a/plotmanager.h
+++ b/plotmanager.h
@@ -7,6 +7,7 @@
 #include <QColor>
 #include <QMouseEvent>
 #include <QMap>
+#include <QPoint>
 
 #include "network.h"
 
@@ -51,6 +52,10 @@ private:
     void updateTracerText(QCPItemTracer *tracer, QCPItemText *text);
     void updateTracers();
     void checkForTracerDrag(QMouseEvent *event, QCPItemTracer *tracer);
+    void configureCursorStyles(PlotType type);
+    QCPGraph *firstGraph() const;
+    QCPCurve *firstSmithCurve() const;
+    QCPCurve *smithCurveAt(const QPoint &pos) const;
     void setupSmithGrid();
     void clearSmithGrid();
     void clearSmithMarkers();
@@ -76,6 +81,7 @@ private:
     QMap<QCPItemTracer*, QCPCurve*> m_tracerCurves;
     QMap<QCPItemTracer*, int> m_tracerIndices;
     bool m_keepAspectConnected;
+    PlotType m_currentPlotType;
 };
 
 #endif // PLOTMANAGER_H


### PR DESCRIPTION
## Summary
- restore crosshair-style cartesian cursors and keep their behaviour aligned with legacy releases
- ensure Smith chart cursors attach only to network curves and keep their selections across plot updates
- allow Smith chart cursors to switch between curves while dragging without ever snapping to the graticule

## Testing
- ./test.sh *(fails: Qt6Widgets/Qt6Gui/Qt6Core/Qt6PrintSupport pkg-config files not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c88341ef608326866cfe21ffdc1f60