### PR TITLE
Guard plot update logging behind debug flag

### DIFF
--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -112,7 +112,9 @@ QCPAbstractPlottable* PlotManager::plot(const QVector<double> &x, const QVector<
 
 void PlotManager::updatePlots(const QStringList& sparams, PlotType type)
 {
-    qInfo("  updatePlots()");
+#ifdef FSNPVIEW_ENABLE_PLOT_DEBUG
+    qDebug() << "  updatePlots()";
+#endif
     QStringList required_graphs;
     QString suffix;
 


### PR DESCRIPTION
## Summary
- replace the unconditional qInfo call in PlotManager::updatePlots with an optional qDebug() that is compiled in only when FSNPVIEW_ENABLE_PLOT_DEBUG is defined

## Testing
- ./test.sh *(fails: Qt6 pkg-config entries not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c88c75dcf4832684331ddc10a8f72c