### PR TITLE
Remove unused Free drag mode

### DIFF
--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -447,12 +447,6 @@ void PlotManager::mouseMove(QMouseEvent *event)
             double key = m_plot->xAxis->pixelToCoord(event->pos().x());
             mDraggedTracer->setGraphKey(key);
         }
-        else if (mDragMode == DragMode::Free)
-        {
-            double x = m_plot->xAxis->pixelToCoord(event->pos().x());
-            double y = m_plot->yAxis->pixelToCoord(event->pos().y());
-            mDraggedTracer->position->setCoords(x, y);
-        }
         else if (mDragMode == DragMode::Curve)
         {
             QCPCurve *curve = m_tracerCurves.value(mDraggedTracer, nullptr);

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -44,7 +44,7 @@ public slots:
     void keepAspectRatio();
 
 private:
-    enum class DragMode { None, Vertical, Horizontal, Free, Curve };
+    enum class DragMode { None, Vertical, Horizontal, Curve };
     QCPAbstractPlottable* plot(const QVector<double> &x, const QVector<double> &y, const QColor &color,
               const QString &name, Network* network, PlotType type,
               Qt::PenStyle style = Qt::SolidLine);


### PR DESCRIPTION
## Summary
- remove the unused DragMode::Free enumerator from PlotManager
- drop the dead mouseMove branch that relied on the removed drag mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c88c07706c8326ab3fc72ccb7cee28