### PR TITLE
Add lossless 50 Ω transmission line lumped network

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -170,6 +170,7 @@ void MainWindow::populateLumpedNetworkTable()
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::C_shunt, 1e-12));
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::L_series, 1e-9));
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::L_shunt, 1e-9));
+    m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::TransmissionLine, 0.1));
 
     for (auto network_ptr : qAsConst(m_networks)) {
         if (dynamic_cast<NetworkLumped*>(network_ptr)) {

--- a/networklumped.h
+++ b/networklumped.h
@@ -13,7 +13,8 @@ public:
         C_series,
         C_shunt,
         L_series,
-        L_shunt
+        L_shunt,
+        TransmissionLine
     };
 
     explicit NetworkLumped(NetworkType type, double value, QObject *parent = nullptr);


### PR DESCRIPTION
## Summary
- add a TransmissionLine option to `NetworkLumped` to model an ideal 50 Ω TEM line with configurable length
- compute the line's ABCD parameters using lossless transmission-line equations and share a reusable π constant
- list the new element in the lumped-network table with a default 0.1 m length for quick use

## Testing
- ./test.sh *(fails: Qt6 pkg-config files are not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8920991688326831a64ac9fdb2934