### PR TITLE
Implement consistent delete behavior

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -87,5 +87,16 @@ private:
     NetworkItemModel* m_network_files_model;
     NetworkItemModel* m_network_lumped_model;
     NetworkItemModel* m_network_cascade_model;
+
+    enum class SelectionOrigin
+    {
+        None,
+        Graph,
+        Files,
+        Lumped,
+        Cascade
+    };
+
+    SelectionOrigin m_lastSelectionOrigin;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary
- track where selections originate and synchronize graph/table selections without triggering unwanted delete operations
- overhaul delete-key handling to hide selected graphs, remove file networks, and deactivate lumped/cascade entries according to focus and selection
- only plot cascade responses when active and tag cascade graphs so delete actions can deactivate the cascade

## Testing
- ./test.sh *(fails: Qt6 development packages are unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c740317c8326ad81bb97538b5890