### PR TITLE
Format plot tick labels with engineering notation

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -527,14 +527,9 @@ void MainWindow::on_checkBoxLegend_checkStateChanged(const Qt::CheckState &arg1)
 void MainWindow::on_checkBox_checkStateChanged(const Qt::CheckState &arg1)
 {
     if (arg1 == Qt::Checked) {
-        ui->widgetGraph->xAxis->setScaleType(QCPAxis::stLogarithmic);
-        QSharedPointer<QCPAxisTickerLog> logTicker(new QCPAxisTickerLog);
-        logTicker->setSubTickCount(8);
-        logTicker->setLogBase(10);
-        ui->widgetGraph->xAxis->setTicker(logTicker);
+        m_plot_manager->setXAxisScaleType(QCPAxis::stLogarithmic);
     } else {
-        ui->widgetGraph->xAxis->setScaleType(QCPAxis::stLinear);
-        ui->widgetGraph->xAxis->setTicker(QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
+        m_plot_manager->setXAxisScaleType(QCPAxis::stLinear);
     }
     ui->widgetGraph->replot();
 }

--- a/network.cpp
+++ b/network.cpp
@@ -31,13 +31,13 @@ Eigen::Vector4cd Network::abcd2s(const Eigen::Matrix2cd& abcd, double z0)
     return s;
 }
 
-QString Network::formatEngineering(double value)
+QString Network::formatEngineering(double value, bool padMantissa)
 {
     if (!std::isfinite(value))
         return QString::number(value);
 
     if (value == 0.0)
-        return QStringLiteral("000.00e+00");
+        return padMantissa ? QStringLiteral("000.00e+00") : QStringLiteral("0.00e+00");
 
     double absValue = std::fabs(value);
     int exponent = static_cast<int>(std::floor(std::log10(absValue)));
@@ -60,9 +60,12 @@ QString Network::formatEngineering(double value)
         dotIndex = mantissaStr.indexOf('.');
     }
 
-    int integerDigits = dotIndex;
-    if (integerDigits < 3)
-        mantissaStr.prepend(QString(3 - integerDigits, '0'));
+    if (padMantissa)
+    {
+        int integerDigits = dotIndex;
+        if (integerDigits < 3)
+            mantissaStr.prepend(QString(3 - integerDigits, '0'));
+    }
 
     QString signStr = value < 0 ? QStringLiteral("-") : QString();
     QString exponentStr = QString::number(std::abs(engineeringExponent)).rightJustified(2, '0');

--- a/network.h
+++ b/network.h
@@ -20,7 +20,7 @@ public:
 
     static Eigen::Matrix2cd s2abcd(const std::complex<double>& s11, const std::complex<double>& s12, const std::complex<double>& s21, const std::complex<double>& s22, double z0 = 50.0);
     static Eigen::Vector4cd abcd2s(const Eigen::Matrix2cd& abcd, double z0 = 50.0);
-    static QString formatEngineering(double value);
+    static QString formatEngineering(double value, bool padMantissa = true);
 
     virtual QString name() const = 0;
     virtual Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const = 0;

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -10,6 +10,7 @@
 #include <QPoint>
 
 #include "network.h"
+#include "qcustomplot.h"
 
 class QCustomPlot;
 class Network;
@@ -32,6 +33,7 @@ public:
     void updatePlots(const QStringList& sparams, PlotType type);
     void autoscale();
     QColor nextColor();
+    void setXAxisScaleType(QCPAxis::ScaleType type);
 
 public slots:
     void mouseDoubleClick(QMouseEvent *event);
@@ -60,6 +62,7 @@ private:
     void clearSmithGrid();
     void clearSmithMarkers();
     void addSmithMarkers(const QVector<double>& x, const QVector<double>& y, const QColor& color);
+    void updateAxisTickers();
 
 
     QCustomPlot* m_plot;


### PR DESCRIPTION
## Summary
- add custom engineering axis tickers so plot axes render in engineering notation without leading zeros
- extend Network::formatEngineering to optionally skip mantissa padding and reuse it for tick labels
- move x-axis scale toggling into PlotManager to keep ticker setup consistent

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9ce797b548326aafa6bab3ce63611