### PR TITLE
Improve Touchstone parser and add writer

### DIFF
--- a/parser_touchstone.cpp
+++ b/parser_touchstone.cpp
@@ -1,19 +1,21 @@
 #include "parser_touchstone.h"
+
 #include <Eigen/Dense>
+
 #include <algorithm>
+#include <cerrno>
 #include <cctype>
 #include <cmath>
 #include <complex>
+#include <cstdlib>
 #include <fstream>
+#include <iomanip>
 #include <optional>
-#include <regex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 namespace ts {
 
@@ -27,115 +29,187 @@ struct OptionsLine {
 };
 
 std::string to_upper(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){ return std::toupper(c); });
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
     return s;
 }
 
 std::string trim(const std::string& s) {
-    size_t a = 0, b = s.size();
-    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
-    while (b > a && std::isspace(static_cast<unsigned char>(s[b-1]))) --b;
+    std::size_t a = 0;
+    std::size_t b = s.size();
+    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) {
+        ++a;
+    }
+    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) {
+        --b;
+    }
     return s.substr(a, b - a);
 }
 
 std::string strip_comment(const std::string& s) {
-    auto pos = s.find('!');
-    return trim(pos == std::string::npos ? s : s.substr(0, pos));
+    const std::size_t pos = s.find('!');
+    const std::string without_comment = pos == std::string::npos ? s : s.substr(0, pos);
+    return trim(without_comment);
 }
 
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegToRad = kPi / 180.0;
+constexpr double kRadToDeg = 180.0 / kPi;
+
 double unit_scale_to_hz(const std::string& u_upper) {
-    if (u_upper == "HZ") return 1.0;
-    if (u_upper == "KHZ") return 1e3;
-    if (u_upper == "MHZ") return 1e6;
-    if (u_upper == "GHZ") return 1e9;
+    if (u_upper == "HZ") {
+        return 1.0;
+    }
+    if (u_upper == "KHZ") {
+        return 1e3;
+    }
+    if (u_upper == "MHZ") {
+        return 1e6;
+    }
+    if (u_upper == "GHZ") {
+        return 1e9;
+    }
     throw std::runtime_error("Unknown frequency unit: " + u_upper);
 }
 
+double hz_to_unit_scale(const std::string& u_upper) {
+    const double scale = unit_scale_to_hz(u_upper);
+    if (scale == 0.0) {
+        throw std::runtime_error("Invalid frequency scale for unit: " + u_upper);
+    }
+    return 1.0 / scale;
+}
+
 std::optional<int> infer_ports_from_extension(const std::string& path) {
-    std::regex re(".*\\.s(\\d+)p(\\..*)?$", std::regex::icase);
-    std::smatch m;
-    if (std::regex_match(path, m, re)) {
-        return std::stoi(m[1].str());
+    if (path.empty()) {
+        return std::nullopt;
+    }
+    std::string lower;
+    lower.reserve(path.size());
+    for (unsigned char c : path) {
+        lower.push_back(static_cast<char>(std::tolower(c)));
+    }
+    const std::size_t marker = lower.rfind(".s");
+    if (marker == std::string::npos || marker + 2 >= lower.size()) {
+        return std::nullopt;
+    }
+    std::size_t digit_begin = marker + 2;
+    std::size_t digit_end = digit_begin;
+    while (digit_end < lower.size() && std::isdigit(static_cast<unsigned char>(lower[digit_end]))) {
+        ++digit_end;
+    }
+    if (digit_end == digit_begin) {
+        return std::nullopt;
+    }
+    if (digit_end >= lower.size() || lower[digit_end] != 'p') {
+        return std::nullopt;
+    }
+    try {
+        const int ports = std::stoi(lower.substr(digit_begin, digit_end - digit_begin));
+        if (ports > 0) {
+            return ports;
+        }
+    } catch (const std::exception&) {
+        return std::nullopt;
     }
     return std::nullopt;
 }
 
 OptionsLine parse_options_line(const std::string& raw) {
     OptionsLine opts;
-    std::string s = to_upper(strip_comment(raw));
+    const std::string s = to_upper(strip_comment(raw));
     if (s.empty() || s[0] != '#') {
         throw std::runtime_error("Options line must start with '#'");
     }
     std::istringstream iss(s.substr(1));
     std::string tok;
     std::vector<std::string> toks;
-    while (iss >> tok) toks.push_back(tok);
+    while (iss >> tok) {
+        toks.push_back(tok);
+    }
 
-    for (const auto& t : toks) {
-        if (t == "HZ" || t == "KHZ" || t == "MHZ" || t == "GHZ") { opts.freq_unit = t; break; }
+    for (const std::string& t : toks) {
+        if (t == "HZ" || t == "KHZ" || t == "MHZ" || t == "GHZ") {
+            opts.freq_unit = t;
+            break;
+        }
     }
-    for (const auto& t : toks) {
-        if (t == "S" || t == "Y" || t == "Z" || t == "H" || t == "G") { opts.parameter = t; break; }
+    for (const std::string& t : toks) {
+        if (t == "S" || t == "Y" || t == "Z" || t == "H" || t == "G") {
+            opts.parameter = t;
+            break;
+        }
     }
-    for (const auto& t : toks) {
-        if (t == "RI" || t == "MA" || t == "DB") { opts.format = t; break; }
+    for (const std::string& t : toks) {
+        if (t == "RI" || t == "MA" || t == "DB") {
+            opts.format = t;
+            break;
+        }
     }
-    for (size_t i = 0; i + 1 < toks.size(); ++i) {
+    for (std::size_t i = 0; i + 1 < toks.size(); ++i) {
         if (toks[i] == "R") {
-            opts.R = std::stod(toks[i+1]);
+            try {
+                opts.R = std::stod(toks[i + 1]);
+            } catch (const std::exception&) {
+                throw std::runtime_error("Invalid reference impedance value in options line: " + raw);
+            }
             break;
         }
     }
     return opts;
 }
 
-std::vector<std::string> read_logical_lines(std::istream& in) {
-    std::vector<std::string> lines;
-    std::string line;
-    std::string current;
-
-    while (std::getline(in, line)) {
-        if (!line.empty() && (line.back() == '\r')) line.pop_back();
-        std::string stripped = strip_comment(line);
-        if (stripped.empty()) continue;
-        if (!stripped.empty() && stripped[0] == '+') {
-            if (current.empty()) {
-                current = trim(stripped.substr(1));
-            } else {
-                current += ' ';
-                current += trim(stripped.substr(1));
-            }
-            continue;
-        }
-        if (!current.empty()) {
-            lines.push_back(trim(current));
-            current.clear();
-        }
-        current = trim(stripped);
-    }
-    if (!current.empty()) lines.push_back(trim(current));
-    return lines;
-}
-
 std::vector<double> tokenize_numbers(const std::string& s) {
     std::vector<double> out;
-    std::istringstream iss(s);
-    double v;
-    while (iss >> v) out.push_back(v);
+    const char* ptr = s.c_str();
+    char* end = nullptr;
+    errno = 0;
+    while (*ptr != '\0') {
+        const double value = std::strtod(ptr, &end);
+        if (end == ptr) {
+            while (*ptr != '\0' && std::isspace(static_cast<unsigned char>(*ptr))) {
+                ++ptr;
+            }
+            if (*ptr != '\0') {
+                throw std::runtime_error("Invalid numeric token in Touchstone data row: '" + s + "'");
+            }
+            break;
+        }
+        if (errno == ERANGE) {
+            throw std::runtime_error("Numeric value out of range in Touchstone data row: '" + s + "'");
+        }
+        out.push_back(value);
+        ptr = end;
+        errno = 0;
+    }
     return out;
 }
 
 std::complex<double> pair_to_complex(double a, double b, const std::string& fmt_upper) {
     if (fmt_upper == "RI") {
         return {a, b};
-    } else if (fmt_upper == "MA") {
-        double mag = a;
-        double ang_rad = b * M_PI / 180.0;
-        return std::polar(mag, ang_rad);
-    } else if (fmt_upper == "DB") {
-        double mag = std::pow(10.0, a / 20.0);
-        double ang_rad = b * M_PI / 180.0;
-        return std::polar(mag, ang_rad);
+    }
+    if (fmt_upper == "MA") {
+        return std::polar(a, b * kDegToRad);
+    }
+    if (fmt_upper == "DB") {
+        const double mag = std::pow(10.0, a / 20.0);
+        return std::polar(mag, b * kDegToRad);
+    }
+    throw std::runtime_error("Unsupported format: " + fmt_upper);
+}
+
+std::pair<double, double> complex_to_pair(const std::complex<double>& value, const std::string& fmt_upper) {
+    if (fmt_upper == "RI") {
+        return {std::real(value), std::imag(value)};
+    }
+    const double magnitude = std::abs(value);
+    const double angle_deg = std::arg(value) * kRadToDeg;
+    if (fmt_upper == "MA") {
+        return {magnitude, angle_deg};
+    }
+    if (fmt_upper == "DB") {
+        const double magnitude_db = 20.0 * std::log10(magnitude);
+        return {magnitude_db, angle_deg};
     }
     throw std::runtime_error("Unsupported format: " + fmt_upper);
 }
@@ -144,71 +218,144 @@ std::complex<double> pair_to_complex(double a, double b, const std::string& fmt_
 
 TouchstoneData parse_touchstone_stream(std::istream& in, const std::string& source_name, std::optional<int> ports_hint) {
     using namespace detail;
-    auto logical = read_logical_lines(in);
-    if (logical.empty()) throw std::runtime_error("Empty Touchstone file: " + source_name);
 
     OptionsLine opts;
-    size_t opt_idx = std::string::npos;
-    for (size_t i = 0; i < logical.size(); ++i) {
-        if (!logical[i].empty() && logical[i][0] == '#') { opt_idx = i; break; }
-    }
-    if (opt_idx != std::string::npos) {
-        opts = parse_options_line(logical[opt_idx]);
-    }
+    double freq_scale = unit_scale_to_hz(opts.freq_unit);
 
-    std::vector<std::vector<double>> rows;
-    rows.reserve(logical.size());
-    for (size_t i = (opt_idx == std::string::npos ? 0 : opt_idx + 1); i < logical.size(); ++i) {
-        const auto nums = tokenize_numbers(logical[i]);
-        if (!nums.empty()) rows.push_back(nums);
-    }
-    if (rows.empty()) throw std::runtime_error("No numeric data rows found in: " + source_name);
+    int ports = ports_hint && *ports_hint > 0 ? *ports_hint : 0;
+    std::size_t values_per_row = ports > 0 ? static_cast<std::size_t>(ports) * static_cast<std::size_t>(ports) : 0;
+    std::size_t expected_cols = values_per_row > 0 ? 1 + 2ull * values_per_row : 0;
 
-    int P = 0;
-    if (ports_hint && *ports_hint > 0) {
-        P = *ports_hint;
-    } else {
-        const size_t cols = rows.front().size();
-        if (cols < 1 + 2) throw std::runtime_error("Data row too short to infer port count in: " + source_name);
-        bool inferred = false;
-        for (int p = 1; p <= 128; ++p) {
-            if (cols == 1 + 2ull * p * p) { P = p; inferred = true; break; }
+    std::vector<double> frequencies_hz;
+    std::vector<std::complex<double>> sparams_values;
+
+    std::string logical_line;
+    std::size_t logical_line_number = 0;
+
+    const auto process_line = [&](const std::string& logical, std::size_t line_number) {
+        if (logical.empty()) {
+            return;
         }
-        if (!inferred) {
-            throw std::runtime_error("Could not infer port count from column count (" + std::to_string(cols) + ") in: " + source_name);
+        if (logical[0] == '#') {
+            opts = parse_options_line(logical);
+            freq_scale = unit_scale_to_hz(opts.freq_unit);
+            return;
         }
+
+        const std::vector<double> numbers = tokenize_numbers(logical);
+        if (numbers.empty()) {
+            return;
+        }
+
+        if (ports <= 0) {
+            const std::size_t cols = numbers.size();
+            bool matched = false;
+            constexpr int kMaxPortsToInfer = 128;
+            for (int candidate = 1; candidate <= kMaxPortsToInfer; ++candidate) {
+                const std::size_t candidate_cols = 1 + 2ull * static_cast<std::size_t>(candidate) * static_cast<std::size_t>(candidate);
+                if (cols == candidate_cols) {
+                    ports = candidate;
+                    values_per_row = static_cast<std::size_t>(ports) * static_cast<std::size_t>(ports);
+                    expected_cols = candidate_cols;
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                throw std::runtime_error("Could not infer port count from column count (" + std::to_string(cols) + ") in " + source_name + ", line " + std::to_string(line_number));
+            }
+        }
+
+        if (expected_cols == 0) {
+            values_per_row = static_cast<std::size_t>(ports) * static_cast<std::size_t>(ports);
+            expected_cols = 1 + 2ull * values_per_row;
+        }
+
+        if (numbers.size() != expected_cols) {
+            throw std::runtime_error("Row at line " + std::to_string(line_number) + " in " + source_name + ": expected " + std::to_string(expected_cols) + " numeric columns, got " + std::to_string(numbers.size()));
+        }
+
+        frequencies_hz.push_back(numbers[0] * freq_scale);
+        for (std::size_t idx = 0; idx < values_per_row; ++idx) {
+            const double a = numbers[1 + idx * 2];
+            const double b = numbers[1 + idx * 2 + 1];
+            sparams_values.push_back(pair_to_complex(a, b, opts.format));
+        }
+    };
+
+    std::string physical_line;
+    std::size_t physical_line_number = 0;
+    while (std::getline(in, physical_line)) {
+        ++physical_line_number;
+        if (!physical_line.empty() && physical_line.back() == '\r') {
+            physical_line.pop_back();
+        }
+
+        const std::size_t excl_pos = physical_line.find('!');
+        const std::string without_comment = excl_pos == std::string::npos ? physical_line : physical_line.substr(0, excl_pos);
+        std::string trimmed = trim(without_comment);
+        if (trimmed.empty()) {
+            continue;
+        }
+
+        if (!trimmed.empty() && trimmed[0] == '+') {
+            trimmed.erase(trimmed.begin());
+            trimmed = trim(trimmed);
+            if (logical_line.empty()) {
+                logical_line = trimmed;
+                logical_line_number = physical_line_number;
+            } else {
+                if (!trimmed.empty()) {
+                    logical_line.push_back(' ');
+                    logical_line += trimmed;
+                }
+            }
+            continue;
+        }
+
+        if (!logical_line.empty()) {
+            process_line(logical_line, logical_line_number);
+            logical_line.clear();
+        }
+        logical_line = trimmed;
+        logical_line_number = physical_line_number;
     }
 
-    const size_t N = rows.size();
+    if (!logical_line.empty()) {
+        process_line(logical_line, logical_line_number);
+    }
+
+    if (frequencies_hz.empty()) {
+        throw std::runtime_error("No numeric data rows found in: " + source_name);
+    }
+
+    if (ports <= 0) {
+        throw std::runtime_error("Failed to determine port count for: " + source_name);
+    }
+
+    const std::size_t values_expected = frequencies_hz.size() * (static_cast<std::size_t>(ports) * static_cast<std::size_t>(ports));
+    if (sparams_values.size() != values_expected) {
+        throw std::runtime_error("Data size mismatch while parsing Touchstone file: " + source_name);
+    }
+
     TouchstoneData out;
-    out.ports = P;
+    out.ports = ports;
     out.parameter = opts.parameter;
     out.format = opts.format;
     out.freq_unit = opts.freq_unit;
     out.R = opts.R;
 
-    out.freq.resize(static_cast<Eigen::Index>(N));
-    out.sparams.resize(static_cast<Eigen::Index>(N), static_cast<Eigen::Index>(P*P));
+    const Eigen::Index row_count = static_cast<Eigen::Index>(frequencies_hz.size());
+    const Eigen::Index col_count = static_cast<Eigen::Index>(ports * ports);
 
-    const double scale = unit_scale_to_hz(opts.freq_unit);
+    out.freq.resize(row_count);
+    out.sparams.resize(row_count, col_count);
 
-    for (size_t k = 0; k < N; ++k) {
-        const auto& row = rows[k];
-        const size_t expected_cols = 1 + 2ull * P * P;
-        if (row.size() != expected_cols) {
-            throw std::runtime_error(
-                "Row " + std::to_string(k) + ": expected " + std::to_string(expected_cols) +
-                " numeric columns (freq + pairs), got " + std::to_string(row.size())
-                );
-        }
-        const double f_user = row[0];
-        out.freq[static_cast<Eigen::Index>(k)] = f_user * scale;
-
-        for (int m = 0; m < P * P; ++m) {
-            double a = row[1 + 2*m + 0];
-            double b = row[1 + 2*m + 1];
-            std::complex<double> c = pair_to_complex(a, b, opts.format);
-            out.sparams(static_cast<Eigen::Index>(k), m) = c;
+    for (Eigen::Index row = 0; row < row_count; ++row) {
+        out.freq[row] = frequencies_hz[static_cast<std::size_t>(row)];
+        for (Eigen::Index col = 0; col < col_count; ++col) {
+            const std::size_t flat_index = static_cast<std::size_t>(row) * static_cast<std::size_t>(col_count) + static_cast<std::size_t>(col);
+            out.sparams(row, col) = sparams_values[flat_index];
         }
     }
 
@@ -216,18 +363,67 @@ TouchstoneData parse_touchstone_stream(std::istream& in, const std::string& sour
 }
 
 TouchstoneData parse_touchstone(const std::string& path) {
-    using namespace detail;
     std::ifstream fin(path);
-    std::cout << "Hello, path is:" << path << std::endl;
-
-
-    if (!fin) throw std::runtime_error("Failed to open Touchstone file: " + path);
-    std::optional<int> hint = infer_ports_from_extension(path);
+    if (!fin) {
+        throw std::runtime_error("Failed to open Touchstone file: " + path);
+    }
+    const std::optional<int> hint = detail::infer_ports_from_extension(path);
     return parse_touchstone_stream(fin, path, hint);
 }
 
 std::complex<double> get_sparam(const TouchstoneData& data, Eigen::Index k, int i, int j) {
-    return data.sparams(k, i*data.ports + j);
+    return data.sparams(k, i * data.ports + j);
+}
+
+void write_touchstone_stream(const TouchstoneData& data, std::ostream& out) {
+    using namespace detail;
+
+    if (data.ports <= 0) {
+        throw std::runtime_error("Touchstone data must have a positive number of ports to be written");
+    }
+
+    const Eigen::Index expected_cols = static_cast<Eigen::Index>(data.ports) * static_cast<Eigen::Index>(data.ports);
+    if (data.sparams.cols() != expected_cols) {
+        throw std::runtime_error("Touchstone data has unexpected number of columns for S-parameters");
+    }
+    if (data.sparams.rows() != data.freq.size()) {
+        throw std::runtime_error("Frequency vector length and S-parameter rows do not match");
+    }
+
+    const std::string freq_unit_upper = data.freq_unit.empty() ? std::string("HZ") : to_upper(data.freq_unit);
+    const std::string parameter_upper = data.parameter.empty() ? std::string("S") : to_upper(data.parameter);
+    const std::string format_upper = data.format.empty() ? std::string("RI") : to_upper(data.format);
+
+    const double freq_scale = hz_to_unit_scale(freq_unit_upper);
+
+    out << "# " << freq_unit_upper << ' ' << parameter_upper << ' ' << format_upper << " R " << data.R << '\n';
+
+    const std::ostream::fmtflags original_flags = out.flags();
+    const std::streamsize original_precision = out.precision();
+    out.setf(std::ios::scientific);
+    out.setf(std::ios::uppercase);
+    out << std::setprecision(15);
+
+    const Eigen::Index rows = data.sparams.rows();
+    for (Eigen::Index row = 0; row < rows; ++row) {
+        out << data.freq[row] * freq_scale;
+        for (Eigen::Index col = 0; col < expected_cols; ++col) {
+            const auto pair = complex_to_pair(data.sparams(row, col), format_upper);
+            out << ' ' << pair.first << ' ' << pair.second;
+        }
+        out << '\n';
+    }
+
+    out.precision(original_precision);
+    out.flags(original_flags);
+}
+
+void write_touchstone(const TouchstoneData& data, const std::string& path) {
+    std::ofstream fout(path);
+    if (!fout) {
+        throw std::runtime_error("Failed to open Touchstone file for writing: " + path);
+    }
+    write_touchstone_stream(data, fout);
 }
 
 } // namespace ts

--- a/parser_touchstone.h
+++ b/parser_touchstone.h
@@ -2,9 +2,10 @@
 
 #include <Eigen/Dense>
 #include <complex>
-#include <optional>
-#include <string>
 #include <istream>
+#include <optional>
+#include <ostream>
+#include <string>
 
 namespace ts {
 
@@ -24,5 +25,9 @@ TouchstoneData parse_touchstone_stream(std::istream& in, const std::string& sour
 TouchstoneData parse_touchstone(const std::string& path);
 
 std::complex<double> get_sparam(const TouchstoneData& data, Eigen::Index k, int i, int j);
+
+void write_touchstone_stream(const TouchstoneData& data, std::ostream& out);
+
+void write_touchstone(const TouchstoneData& data, const std::string& path);
 
 } // namespace ts


### PR DESCRIPTION
## Summary
- Reworked the Touchstone parser to stream input, validate numeric tokens, and provide clearer errors while inferring port counts.
- Added conversion helpers and public APIs for emitting Touchstone files from in-memory data structures.
- Extended parser unit tests with write/read roundtrip coverage and error scenarios for the new writer.

## Testing
- ./test.sh *(fails: missing Qt6 pkg-config entries in the environment)*
- g++ -std=c++17 -I/usr/include/eigen3 -I. tests/parser_touchstone_tests.cpp parser_touchstone.cpp -o parser_touchstone_tests *(fails: Eigen headers are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e549082083268c4f3d13dbf9afcd