### PR TITLE
Refine network names and parameter formatting

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -258,7 +258,7 @@ void MainWindow::populateLumpedNetworkTable()
             colorItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             colorItem->setBackground(network_ptr->color());
             row.append(colorItem);
-            QStandardItem* nameItem = new QStandardItem(network_ptr->name());
+            QStandardItem* nameItem = new QStandardItem(network_ptr->displayName());
             nameItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             row.append(nameItem);
             appendParameterItems(row, network_ptr);
@@ -329,7 +329,7 @@ void MainWindow::onNetworkDropped(Network* network, int row, const QModelIndex& 
         colorItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         colorItem->setBackground(cloned->color());
         items.append(colorItem);
-        QStandardItem* nameItem = new QStandardItem(cloned->name());
+        QStandardItem* nameItem = new QStandardItem(cloned->displayName());
         nameItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         items.append(nameItem);
         appendParameterItems(items, cloned);
@@ -431,7 +431,7 @@ void MainWindow::onNetworkLumpedModelChanged(QStandardItem *item)
             double val = item->text().toDouble(&ok);
             if (ok) {
                 network->setParameterValue(parameterIndex, val);
-                m_network_lumped_model->item(item->row(), 2)->setText(network->name());
+                m_network_lumped_model->item(item->row(), 2)->setText(network->displayName());
                 updatePlots();
             }
             {
@@ -470,7 +470,7 @@ void MainWindow::onNetworkCascadeModelChanged(QStandardItem *item)
             double val = item->text().toDouble(&ok);
             if (ok) {
                 network->setParameterValue(parameterIndex, val);
-                m_network_cascade_model->item(item->row(), 2)->setText(network->name());
+                m_network_cascade_model->item(item->row(), 2)->setText(network->displayName());
                 updatePlots();
             }
             {

--- a/network.h
+++ b/network.h
@@ -23,6 +23,7 @@ public:
     static QString formatEngineering(double value, bool padMantissa = true);
 
     virtual QString name() const = 0;
+    virtual QString displayName() const;
     virtual Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const = 0;
     virtual QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) = 0;
     virtual Network* clone(QObject* parent = nullptr) const = 0;

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -54,18 +54,28 @@ Network* NetworkLumped::clone(QObject* parent) const
     return copy;
 }
 
+QString NetworkLumped::typeName() const
+{
+    switch (m_type) {
+    case NetworkType::R_series: return QStringLiteral("R_series");
+    case NetworkType::R_shunt:  return QStringLiteral("R_shunt");
+    case NetworkType::C_series: return QStringLiteral("C_series");
+    case NetworkType::C_shunt:  return QStringLiteral("C_shunt");
+    case NetworkType::L_series: return QStringLiteral("L_series");
+    case NetworkType::L_shunt:  return QStringLiteral("L_shunt");
+    case NetworkType::TransmissionLine: return QStringLiteral("TL_50Ω");
+    }
+    return QString();
+}
+
+QString NetworkLumped::displayName() const
+{
+    return typeName();
+}
+
 QString NetworkLumped::name() const
 {
-    QString name;
-    switch (m_type) {
-    case NetworkType::R_series: name = QStringLiteral("R_series"); break;
-    case NetworkType::R_shunt:  name = QStringLiteral("R_shunt");  break;
-    case NetworkType::C_series: name = QStringLiteral("C_series"); break;
-    case NetworkType::C_shunt:  name = QStringLiteral("C_shunt");  break;
-    case NetworkType::L_series: name = QStringLiteral("L_series"); break;
-    case NetworkType::L_shunt:  name = QStringLiteral("L_shunt");  break;
-    case NetworkType::TransmissionLine: name = QStringLiteral("TL_50Ω"); break;
-    }
+    QString name = typeName();
     QStringList parameterParts;
     for (const auto& parameter : m_parameters) {
         parameterParts.append(QStringLiteral("%1=%2").arg(parameter.description,

--- a/networklumped.h
+++ b/networklumped.h
@@ -24,6 +24,7 @@ public:
     NetworkLumped(NetworkType type, std::initializer_list<double> values, QObject *parent = nullptr);
 
     QString name() const override;
+    QString displayName() const override;
     Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const override;
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override;
     Network* clone(QObject* parent = nullptr) const override;
@@ -49,6 +50,7 @@ private:
 
     void initializeParameters(const QVector<double>& values);
     double parameterValueSI(int index) const;
+    QString typeName() const;
 };
 
 #endif // NETWORKLUMPED_H


### PR DESCRIPTION
## Summary
- add a dedicated display name for networks and keep full names with parameters for legend usage
- update the lumped network table logic to show only the base network name while keeping parameter values in their columns
- change engineering value formatting to match plot tick style with fixed-width whitespace padding for parameter displays

## Testing
- ./build.sh *(fails: missing Qt6Widgets/Qt6Gui/Qt6Core/Qt6PrintSupport pkg-config files in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0d0446848326b397617534ca6e0e