### PR TITLE
Handle multi-line multiport Touchstone data

### DIFF
--- a/tests/parser_touchstone_tests.cpp
+++ b/tests/parser_touchstone_tests.cpp
@@ -18,6 +18,13 @@ void test_basic_parse() {
     std::complex<double> expected = std::polar(expected_mag, expected_ang_rad);
     assert(std::abs(std::real(s11) - std::real(expected)) < 1e-6);
     assert(std::abs(std::imag(s11) - std::imag(expected)) < 1e-6);
+
+    std::complex<double> s21 = ts::get_sparam(data, 0, 1, 0);
+    double expected_s21_mag = std::pow(10.0, -0.078 / 20.0);
+    double expected_s21_ang_rad = -8.647 * M_PI / 180.0;
+    std::complex<double> expected_s21 = std::polar(expected_s21_mag, expected_s21_ang_rad);
+    assert(std::abs(std::real(s21) - std::real(expected_s21)) < 1e-6);
+    assert(std::abs(std::imag(s21) - std::imag(expected_s21)) < 1e-6);
 }
 
 void test_second_file() {
@@ -78,12 +85,25 @@ void test_write_invalid_dimensions() {
     assert(threw);
 }
 
+void test_multiport_files() {
+    ts::TouchstoneData data6 = ts::parse_touchstone("test/a (12).s6p");
+    assert(data6.ports == 6);
+    assert(data6.freq.size() > 0);
+    assert(data6.sparams.cols() == data6.ports * data6.ports);
+
+    ts::TouchstoneData data9 = ts::parse_touchstone("test/a (11).s9p");
+    assert(data9.ports == 9);
+    assert(data9.freq.size() > 0);
+    assert(data9.sparams.cols() == data9.ports * data9.ports);
+}
+
 int main() {
     test_basic_parse();
     test_second_file();
     test_malformed();
     test_write_roundtrip();
     test_write_invalid_dimensions();
+    test_multiport_files();
     std::cout << "All parser tests passed." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- accumulate numeric tokens across physical lines so multi-port Touchstone rows are parsed once the expected number of values is available
- adjust get_sparam indexing to match the Touchstone column ordering
- extend parser tests with S21 coverage and ensure the new .s6p/.s9p samples parse successfully

## Testing
- `./test.sh` *(fails: Qt6 pkg-config files are not available in the container)*
- `g++ -std=c++17 -I/usr/include/eigen3 -I. tests/parser_touchstone_tests.cpp parser_touchstone.cpp -o parser_touchstone_tests` *(fails: Eigen headers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb10670d78832690df6f36e4a92ece