### PR TITLE
Allow configuring lumped transmission line impedance

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -232,7 +232,7 @@ void MainWindow::populateLumpedNetworkTable()
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::C_shunt, {1.0}));
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::L_series, {1.0, 1.0}));
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::L_shunt, {1.0, 1.0}));
-    m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::TransmissionLine, {1e-3}));
+    m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::TransmissionLine, {1e-3, 50.0}));
 
     m_lumpedParameterCount = 0;
     for (auto network_ptr : qAsConst(m_networks)) {


### PR DESCRIPTION
## Summary
- make the lumped transmission line expose its characteristic impedance as an editable parameter while keeping the default at 50 Ω
- adjust the default transmission line instantiation so it initializes both length and impedance

## Testing
- ./test.sh *(fails: missing Qt6 pkg-config entries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc613308e883269dc7c8e621f60aea