### PR TITLE
Fix TDR step response and add tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,10 @@ MOC_INCLUDES="$(pkg-config --cflags Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)"
 
 g++ -std=c++17 -I/usr/include/eigen3 -I. tests/parser_touchstone_tests.cpp parser_touchstone.cpp -o parser_touchstone_tests
 
+g++ -std=c++17 -I/usr/include/eigen3 -I. \
+    tests/tdrcalculator_tests.cpp tdrcalculator.cpp \
+    -o tdrcalculator_tests $(pkg-config --cflags --libs Qt6Core)
+
 # Generate moc files for Qt classes
 $MOC $MOC_INCLUDES plotmanager.h -o moc_plotmanager.cpp
 $MOC $MOC_INCLUDES network.h -o moc_network.cpp
@@ -21,11 +25,12 @@ $MOC $MOC_INCLUDES qcustomplot.h -o moc_qcustomplot.cpp
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
     tests/gui_plot_tests.cpp plotmanager.cpp network.cpp networkfile.cpp \
     networklumped.cpp networkcascade.cpp parser_touchstone.cpp qcustomplot.cpp \
+    tdrcalculator.cpp \
     moc_plotmanager.cpp moc_network.cpp moc_networkfile.cpp moc_networklumped.cpp \
     moc_networkcascade.cpp moc_qcustomplot.cpp \
     -o gui_plot_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)
 
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
     tests/networkcascade_tests.cpp parser_touchstone.cpp network.cpp networkfile.cpp \
-    networkcascade.cpp moc_network.cpp moc_networkfile.cpp moc_networkcascade.cpp \
+    networkcascade.cpp tdrcalculator.cpp moc_network.cpp moc_networkfile.cpp moc_networkcascade.cpp \
     -o networkcascade_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)

--- a/tdrcalculator.cpp
+++ b/tdrcalculator.cpp
@@ -103,6 +103,8 @@ TDRCalculator::Result TDRCalculator::compute(const Eigen::ArrayXd& frequencyHz,
         for (int i = 0; i < n; ++i)
         {
             double w = 0.5 * (1.0 - std::cos(2.0 * kPi * static_cast<double>(i) / denomCount));
+            if (i == 0)
+                w = 1.0;
             uniformReflection(i) *= w;
         }
     }
@@ -142,11 +144,19 @@ TDRCalculator::Result TDRCalculator::compute(const Eigen::ArrayXd& frequencyHz,
     result.distance.reserve(half);
     result.impedance.reserve(half);
 
+    std::vector<std::complex<double>> stepResponse(static_cast<std::size_t>(half));
+    std::complex<double> cumulative(0.0, 0.0);
+    for (int i = 0; i < half; ++i)
+    {
+        cumulative += timeDomain[static_cast<std::size_t>(i)];
+        stepResponse[static_cast<std::size_t>(i)] = cumulative;
+    }
+
     for (int i = 0; i < half; ++i)
     {
         double time = dt * static_cast<double>(i);
         double distance = 0.5 * velocity * time;
-        const std::complex<double>& gamma = timeDomain[static_cast<std::size_t>(i)];
+        const std::complex<double>& gamma = stepResponse[static_cast<std::size_t>(i)];
         std::complex<double> numerator = std::complex<double>(1.0, 0.0) + gamma;
         std::complex<double> denominator = std::complex<double>(1.0, 0.0) - gamma;
         double impedanceValue;

--- a/test.sh
+++ b/test.sh
@@ -6,6 +6,7 @@ set -e
 ./build.sh
 
 ./parser_touchstone_tests
+./tdrcalculator_tests
 QT_QPA_PLATFORM=offscreen ./gui_plot_tests
 ./networkcascade_tests
 

--- a/tests/tdrcalculator_tests.cpp
+++ b/tests/tdrcalculator_tests.cpp
@@ -1,0 +1,84 @@
+#include "tdrcalculator.h"
+
+#include <Eigen/Dense>
+#include <QtGlobal>
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <iostream>
+
+namespace
+{
+constexpr double kPi = 3.14159265358979323846;
+}
+
+void test_step_response_has_plateau()
+{
+    const int sampleCount = 1024;
+    const double frequencySpacing = 10e6; // 10 MHz spacing
+    const double maxFrequency = frequencySpacing * static_cast<double>(sampleCount - 1);
+
+    Eigen::ArrayXd frequency = Eigen::ArrayXd::LinSpaced(sampleCount, 0.0, maxFrequency);
+    Eigen::ArrayXcd reflection(sampleCount);
+
+    const double delay = 10e-9; // 10 ns delay
+    const double amplitude = 0.5; // 50 % reflection
+
+    for (int i = 0; i < sampleCount; ++i)
+    {
+        double phase = -2.0 * kPi * frequency(i) * delay;
+        reflection(i) = std::polar(amplitude, phase);
+    }
+
+    TDRCalculator calculator;
+    TDRCalculator::Parameters params(50.0, 1.0, 299792458.0);
+    auto result = calculator.compute(frequency, reflection, params);
+
+    assert(!result.distance.isEmpty());
+    assert(result.distance.size() == result.impedance.size());
+
+    double velocity = params.speedOfLight / std::sqrt(params.effectivePermittivity);
+    double expectedDistance = 0.5 * velocity * delay;
+
+    int transitionIndex = -1;
+    for (int i = 0; i < result.distance.size(); ++i)
+    {
+        if (result.distance[i] >= expectedDistance)
+        {
+            transitionIndex = i;
+            break;
+        }
+    }
+
+    assert(transitionIndex >= 0);
+
+    int baselineSamples = std::min(transitionIndex, 20);
+    double baselineSum = 0.0;
+    for (int i = 0; i < baselineSamples; ++i)
+        baselineSum += result.impedance[i];
+    double baselineAverage = baselineSamples > 0 ? baselineSum / baselineSamples : params.referenceImpedance;
+
+    double plateauSum = 0.0;
+    int plateauSamples = 0;
+    for (int i = transitionIndex; i < result.impedance.size() && plateauSamples < 40; ++i)
+    {
+        plateauSum += result.impedance[i];
+        ++plateauSamples;
+    }
+    double plateauAverage = plateauSamples > 0 ? plateauSum / plateauSamples : params.referenceImpedance;
+
+    std::cout << "Baseline impedance: " << baselineAverage << '\n';
+    std::cout << "Plateau impedance: " << plateauAverage << '\n';
+
+    assert(std::abs(baselineAverage - params.referenceImpedance) < 10.0);
+    assert((plateauAverage - baselineAverage) > 5.0);
+    std::cout << "TDR calculator step response test passed." << std::endl;
+}
+
+int main()
+{
+    test_step_response_has_plateau();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- ensure the TDR calculator integrates the inverse FFT to produce a step response and keeps the DC component of the window intact
- add a regression test that verifies a sustained impedance plateau and wire it into the build scripts

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68cc64c18c788326b82b8f751515b10a