### PR TITLE
Switch setup script to Qt6 packages

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This script installs the dependencies for the fsnpview project on Debian-based systems.
 set -e
-sudo apt-get update && sudo apt-get install -y build-essential qt5-qmake qtbase5-dev libeigen3-dev
+sudo apt-get update && sudo apt-get install -y build-essential qt6-base-dev qt6-base-dev-tools libeigen3-dev


### PR DESCRIPTION
## Summary
- replace the Qt5 package installs in `setup.sh` with the Qt6 equivalents required for the build tooling

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68d051d0d16083268798c61987daaf01