### PR TITLE
Allow deleting difference plots

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -723,6 +723,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         };
 
         if (graphContext) {
+            m_plot_manager->removeSelectedMathPlots();
             const auto plottables = ui->widgetGraph->selectedPlottables();
             QSet<Network*> networksToHide;
             bool cascadeGraphSelected = false;

--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -1118,12 +1118,41 @@ void PlotManager::createMathPlot()
 
         if (!x.isEmpty())
         {
-            plot(x, y, Qt::red,
-                 QString("%1 - %2").arg(graph1->name()).arg(graph2->name()),
-                 nullptr, PlotType::Magnitude);
+            if (QCPAbstractPlottable *pl = plot(x, y, Qt::red,
+                                               QString("%1 - %2").arg(graph1->name()).arg(graph2->name()),
+                                               nullptr, PlotType::Magnitude))
+            {
+                if (QCPGraph *mathGraph = qobject_cast<QCPGraph*>(pl))
+                    mathGraph->setProperty("math_plot", true);
+            }
             m_plot->replot();
         }
     }
+}
+
+bool PlotManager::removeSelectedMathPlots()
+{
+    if (!m_plot)
+        return false;
+
+    const auto selected = m_plot->selectedPlottables();
+    bool removed = false;
+
+    for (QCPAbstractPlottable *pl : selected)
+    {
+        if (!pl)
+            continue;
+        if (pl->property("math_plot").toBool())
+        {
+            m_plot->removePlottable(pl);
+            removed = true;
+        }
+    }
+
+    if (removed)
+        m_plot->replot();
+
+    return removed;
 }
 
 void PlotManager::selectionChanged()

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -43,6 +43,7 @@ public slots:
     void setCursorAVisible(bool visible);
     void setCursorBVisible(bool visible);
     void createMathPlot();
+    bool removeSelectedMathPlots();
     void selectionChanged();
     void keepAspectRatio();
 


### PR DESCRIPTION
## Summary
- mark generated math/difference plots so they can be removed
- delete selected math plots from the graph when Delete is pressed

## Testing
- ./test.sh *(fails: pkg-config can't find Qt6 packages in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d054e630d883269400b646f4b0b21e