### PR TITLE
Implement time domain gating

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -59,6 +59,11 @@ private slots:
     void on_checkBoxSmith_checkStateChanged(const Qt::CheckState &arg1);
     void on_checkBoxTDR_checkStateChanged(const Qt::CheckState &arg1);
 
+    void on_checkBoxGate_stateChanged(int state);
+    void on_lineEditGateStart_editingFinished();
+    void on_lineEditGateStop_editingFinished();
+    void on_lineEditEpsilonR_editingFinished();
+
     void onNetworkFilesModelChanged(QStandardItem *item);
     void onNetworkLumpedModelChanged(QStandardItem *item);
     void onNetworkCascadeModelChanged(QStandardItem *item);
@@ -86,6 +91,9 @@ private:
     bool isParameterValueColumn(int column) const;
     int parameterIndexFromColumn(int column) const;
     void updateGraphSelectionFromTables();
+    bool applyGateSettingsFromUi();
+    void refreshGateControls();
+    static bool nearlyEqual(double lhs, double rhs);
 
 
     Ui::MainWindow *ui;

--- a/network.cpp
+++ b/network.cpp
@@ -2,6 +2,10 @@
 #include <complex>
 #include <cmath>
 
+namespace {
+Network::TimeGateSettings g_timeGateSettings;
+}
+
 Eigen::Matrix2cd Network::s2abcd(const std::complex<double>& s11, const std::complex<double>& s12, const std::complex<double>& s21, const std::complex<double>& s22, double z0)
 {
     std::complex<double> A = ((1.0 + s11) * (1.0 - s22) + s12 * s21) / (2.0 * s21);
@@ -91,6 +95,16 @@ QString Network::formatEngineering(double value, bool padMantissa)
 QString Network::displayName() const
 {
     return name();
+}
+
+void Network::setTimeGateSettings(const TimeGateSettings& settings)
+{
+    g_timeGateSettings = settings;
+}
+
+Network::TimeGateSettings Network::timeGateSettings()
+{
+    return g_timeGateSettings;
 }
 
 Network::Network(QObject *parent)

--- a/network.h
+++ b/network.h
@@ -30,6 +30,17 @@ public:
     virtual QVector<double> frequencies() const = 0;
     virtual int portCount() const = 0;
 
+    struct TimeGateSettings
+    {
+        bool enabled = false;
+        double startDistance = 0.0;
+        double stopDistance = 0.0;
+        double epsilonR = 1.0;
+    };
+
+    static void setTimeGateSettings(const TimeGateSettings& settings);
+    static TimeGateSettings timeGateSettings();
+
     double fmin() const;
     void setFmin(double fmin);
 

--- a/networkcascade.cpp
+++ b/networkcascade.cpp
@@ -1,6 +1,12 @@
 #include "networkcascade.h"
 #include "tdrcalculator.h"
 #include <limits>
+#include <algorithm>
+#include <optional>
+
+namespace {
+constexpr double pi = 3.14159265358979323846;
+}
 
 NetworkCascade::NetworkCascade(QObject *parent) : Network(parent)
 {
@@ -129,60 +135,75 @@ QPair<QVector<double>, QVector<double>> NetworkCascade::getPlotData(int s_param_
     updateFrequencyRange();
     Eigen::VectorXd freq = Eigen::VectorXd::LinSpaced(2001, m_fmin, m_fmax);
     Eigen::MatrixXcd abcd_matrix = abcd(freq);
-    if (type == PlotType::TDR) {
-        if (s_param_idx != 0 && s_param_idx != 3)
-            return {};
-        Eigen::ArrayXcd sparam(freq.size());
-        for (int i = 0; i < freq.size(); ++i) {
-            Eigen::Matrix2cd abcd_point;
-            abcd_point << abcd_matrix(i, 0), abcd_matrix(i, 1), abcd_matrix(i, 2), abcd_matrix(i, 3);
-            Eigen::Vector4cd s = abcd2s(abcd_point);
-            sparam(i) = s(s_param_idx);
-        }
-        TDRCalculator calculator;
-        auto result = calculator.compute(freq.array(), sparam);
-        return qMakePair(result.distance, result.impedance);
-    }
 
-    QVector<double> xValues, yValues;
-
+    Eigen::ArrayXcd sparam(freq.size());
     for (int i = 0; i < freq.size(); ++i) {
         Eigen::Matrix2cd abcd_point;
         abcd_point << abcd_matrix(i, 0), abcd_matrix(i, 1), abcd_matrix(i, 2), abcd_matrix(i, 3);
         Eigen::Vector4cd s = abcd2s(abcd_point);
-        std::complex<double> s_param = s(s_param_idx);
+        sparam(i) = s(s_param_idx);
+    }
 
-        switch (type) {
-        case PlotType::Magnitude:
-            xValues.append(freq(i));
-            yValues.append(20 * std::log10(std::abs(s_param)));
-            break;
-        case PlotType::Phase:
-            xValues.append(freq(i));
-            yValues.append(std::arg(s_param) * 180.0 / M_PI);
-            break;
-        case PlotType::VSWR:
-            xValues.append(freq(i));
-            yValues.append((1 + std::abs(s_param)) / (1 - std::abs(s_param)));
-            break;
-        case PlotType::Smith:
-            xValues.append(std::real(s_param));
-            yValues.append(std::imag(s_param));
-            break;
-        case PlotType::TDR:
-            break;
+    const int ports = portCount();
+    const int outputPort = s_param_idx % ports;
+    const int inputPort = s_param_idx / ports;
+    const bool isReflectionParam = (outputPort == inputPort);
+
+    Network::TimeGateSettings gateSettings = Network::timeGateSettings();
+    TDRCalculator calculator;
+    TDRCalculator::Parameters tdrParams;
+    tdrParams.effectivePermittivity = std::max(gateSettings.epsilonR, 1.0);
+
+    std::optional<TDRCalculator::GateResult> gateResult;
+    if (gateSettings.enabled && isReflectionParam) {
+        auto gated = calculator.applyGate(freq.array(), sparam,
+                                         gateSettings.startDistance,
+                                         gateSettings.stopDistance,
+                                         gateSettings.epsilonR,
+                                         tdrParams);
+        if (gated) {
+            sparam = gated->gatedReflection;
+            gateResult = std::move(*gated);
         }
     }
 
-    if (type == PlotType::Phase && m_unwrap_phase) {
-        Eigen::Map<Eigen::ArrayXd> yValuesEigen(yValues.data(), yValues.size());
-        Eigen::ArrayXd unwrapped_y = unwrap(yValuesEigen);
-        for(int i = 0; i < unwrapped_y.size(); ++i) {
-            yValues[i] = unwrapped_y[i];
+    QVector<double> freqVector(freq.data(), freq.data() + freq.size());
+
+    switch (type) {
+    case PlotType::Magnitude: {
+        Eigen::ArrayXd magnitude = 20 * sparam.abs().log10();
+        QVector<double> values(magnitude.data(), magnitude.data() + magnitude.size());
+        return qMakePair(freqVector, values);
+    }
+    case PlotType::Phase: {
+        Eigen::ArrayXd phase = sparam.arg() * 180.0 / pi;
+        if (m_unwrap_phase)
+            phase = unwrap(phase);
+        QVector<double> values(phase.data(), phase.data() + phase.size());
+        return qMakePair(freqVector, values);
+    }
+    case PlotType::VSWR: {
+        Eigen::ArrayXd vswr = (1 + sparam.abs()) / (1 - sparam.abs());
+        QVector<double> values(vswr.data(), vswr.data() + vswr.size());
+        return qMakePair(freqVector, values);
+    }
+    case PlotType::Smith: {
+        QVector<double> xValues(sparam.real().data(), sparam.real().data() + sparam.real().size());
+        QVector<double> yValues(sparam.imag().data(), sparam.imag().data() + sparam.imag().size());
+        return qMakePair(xValues, yValues);
+    }
+    case PlotType::TDR:
+        if (!isReflectionParam)
+            return {};
+        if (gateResult)
+            return qMakePair(gateResult->distance, gateResult->impedance);
+        {
+            auto result = calculator.compute(freq.array(), sparam, tdrParams);
+            return qMakePair(result.distance, result.impedance);
         }
     }
 
-    return qMakePair(xValues, yValues);
+    return {};
 }
 
 Network* NetworkCascade::clone(QObject* parent) const

--- a/tdrcalculator.cpp
+++ b/tdrcalculator.cpp
@@ -1,6 +1,7 @@
 #include "tdrcalculator.h"
 
 #include <unsupported/Eigen/FFT>
+#include <QDebug>
 #include <algorithm>
 #include <climits>
 #include <cmath>
@@ -395,8 +396,12 @@ std::optional<TDRCalculator::GateResult> TDRCalculator::applyGate(const Eigen::A
     Eigen::ArrayXd impedance = StepToImpedance(rho, gateParams.referenceImpedance);
 
     Eigen::FFT<double> fft;
+    std::vector<double> impulseVec(ctx.Nfft);
+    for (std::size_t i = 0; i < ctx.Nfft; ++i)
+        impulseVec[i] = gatedImpulse(static_cast<Eigen::Index>(i));
+
     std::vector<std::complex<double>> specFull(ctx.Nfft);
-    fft.fwd(specFull, gatedImpulse);
+    fft.fwd(specFull, impulseVec);
 
     Eigen::ArrayXcd positive(ctx.freqBins.size());
     for (Eigen::Index i = 0; i < positive.size(); ++i)

--- a/tdrcalculator.cpp
+++ b/tdrcalculator.cpp
@@ -2,10 +2,12 @@
 
 #include <unsupported/Eigen/FFT>
 #include <algorithm>
+#include <climits>
 #include <cmath>
 #include <complex>
 #include <limits>
 #include <numeric>
+#include <optional>
 #include <vector>
 
 namespace {
@@ -13,8 +15,29 @@ namespace {
 constexpr double kPi = 3.14159265358979323846;
 constexpr double kC0 = 299792458.0;
 
+struct TransformContext
+{
+    Eigen::ArrayXd freqSorted;
+    Eigen::ArrayXcd reflectionSorted;
+    std::vector<int> permutation; // sorted index -> original index
+    Eigen::ArrayXd freqBins;
+    Eigen::ArrayXcd spectrumPositive;
+    std::vector<std::complex<double>> spectrumFull;
+    Eigen::ArrayXd impulse;
+    double df = 0.0;
+    std::size_t Nfft = 0;
+    double dt = 0.0;
+    double velocity = 0.0;
+};
+
+inline double safeEpsilon(double eps)
+{
+    return (eps > 1.0) ? eps : 1.0;
+}
+
 // Next power of two >= n
-inline std::size_t NextPow2(std::size_t n) {
+inline std::size_t NextPow2(std::size_t n)
+{
     if (n == 0) return 1;
     --n;
     n |= n >> 1;
@@ -29,7 +52,8 @@ inline std::size_t NextPow2(std::size_t n) {
 }
 
 // Apply a cosine taper only at the high-frequency tail
-inline void ApplyHighEndCosineTaper(Eigen::ArrayXcd& oneSided, int edgeCount) {
+inline void ApplyHighEndCosineTaper(Eigen::ArrayXcd& oneSided, int edgeCount)
+{
     const int n = static_cast<int>(oneSided.size());
     if (n <= 2 || edgeCount <= 0 || edgeCount >= n) return;
 
@@ -40,89 +64,87 @@ inline void ApplyHighEndCosineTaper(Eigen::ArrayXcd& oneSided, int edgeCount) {
     }
 }
 
-} // namespace
-
-TDRCalculator::Result TDRCalculator::compute(const Eigen::ArrayXd& frequencyHz,
-                                             const Eigen::ArrayXcd& reflection,
-                                             const Parameters& params) const
+std::optional<TransformContext> PrepareTransform(const Eigen::ArrayXd& frequencyHz,
+                                                 const Eigen::ArrayXcd& reflection,
+                                                 const TDRCalculator::Parameters& params)
 {
-    Result result;
+    TransformContext ctx;
 
-    // Basic validation
     const Eigen::Index m = std::min(frequencyHz.size(), reflection.size());
     if (m < 4) {
         qDebug("Basic validation failed");
-        return result;
+        return std::nullopt;
     }
     qDebug("Basic validation ok");
 
-    // Copy + sort by frequency
     Eigen::ArrayXd f = frequencyHz.head(m);
     Eigen::ArrayXcd s11 = reflection.head(m);
-    std::vector<int> idx(m);
+    std::vector<int> idx(static_cast<std::size_t>(m));
     std::iota(idx.begin(), idx.end(), 0);
     std::stable_sort(idx.begin(), idx.end(),
-                     [&](int a, int b){ return f(a) < f(b); });
+                     [&](int a, int b) { return f(a) < f(b); });
 
-    Eigen::ArrayXd f_sorted(m);
-    Eigen::ArrayXcd s11_sorted(m);
+    ctx.freqSorted.resize(m);
+    ctx.reflectionSorted.resize(m);
+    ctx.permutation.resize(static_cast<std::size_t>(m));
+
     for (Eigen::Index i = 0; i < m; ++i) {
-        f_sorted(i) = f(idx[i]);
-        s11_sorted(i) = s11(idx[i]);
+        const int originalIndex = idx[static_cast<std::size_t>(i)];
+        ctx.freqSorted(i) = f(originalIndex);
+        ctx.reflectionSorted(i) = s11(originalIndex);
+        ctx.permutation[static_cast<std::size_t>(i)] = originalIndex;
     }
 
-    // Estimate df
-    Eigen::ArrayXd df = f_sorted.tail(m - 1) - f_sorted.head(m - 1);
-    const double df_est = df.mean();
-    if (!(df_est > 0.0)) {
+    Eigen::ArrayXd df = ctx.freqSorted.tail(m - 1) - ctx.freqSorted.head(m - 1);
+    ctx.df = df.mean();
+    if (!(ctx.df > 0.0)) {
         qDebug("error: df_est <= 0");
-        return result;
+        return std::nullopt;
     }
     qDebug("ok df_est > 0");
 
-    // Nfft size
     const std::size_t minimalNfft = static_cast<std::size_t>(2 * (m - 1));
-    std::size_t Nfft = NextPow2(minimalNfft);
-    Nfft = std::max<std::size_t>(Nfft, (1u << 17));
-    const std::size_t nBins = Nfft / 2 + 1;
+    ctx.Nfft = NextPow2(minimalNfft);
+    ctx.Nfft = std::max<std::size_t>(ctx.Nfft, (1u << 17));
+    const std::size_t nBins = ctx.Nfft / 2 + 1;
 
-    // Interpolate onto uniform bins
-    Eigen::ArrayXd f_bins(nBins);
-    for (std::size_t i = 0; i < nBins; ++i) f_bins(i) = df_est * double(i);
+    ctx.freqBins.resize(static_cast<int>(nBins));
+    for (std::size_t i = 0; i < nBins; ++i)
+        ctx.freqBins(static_cast<Eigen::Index>(i)) = ctx.df * double(i);
 
-    Eigen::ArrayXcd S11_bins(nBins);
-    const double fmax_meas = f_sorted(m - 1);
+    ctx.spectrumPositive.resize(static_cast<int>(nBins));
+    const double fmaxMeas = ctx.freqSorted(m - 1);
     for (std::size_t i = 0; i < nBins; ++i) {
-        const double fb = f_bins(i);
-        if (fb > fmax_meas) {
-            S11_bins(i) = std::complex<double>(0.0, 0.0);
+        const double fb = ctx.freqBins(static_cast<Eigen::Index>(i));
+        if (fb > fmaxMeas) {
+            ctx.spectrumPositive(static_cast<Eigen::Index>(i)) = std::complex<double>(0.0, 0.0);
         } else {
-            auto it = std::lower_bound(f_sorted.data(), f_sorted.data() + m, fb);
-            if (it == f_sorted.data()) {
-                S11_bins(i) = s11_sorted(0);
-            } else if (it == f_sorted.data() + m) {
-                S11_bins(i) = s11_sorted(m - 1);
+            auto it = std::lower_bound(ctx.freqSorted.data(), ctx.freqSorted.data() + m, fb);
+            if (it == ctx.freqSorted.data()) {
+                ctx.spectrumPositive(static_cast<Eigen::Index>(i)) = ctx.reflectionSorted(0);
+            } else if (it == ctx.freqSorted.data() + m) {
+                ctx.spectrumPositive(static_cast<Eigen::Index>(i)) = ctx.reflectionSorted(m - 1);
             } else {
-                const Eigen::Index hi = static_cast<Eigen::Index>(it - f_sorted.data());
+                const Eigen::Index hi = static_cast<Eigen::Index>(it - ctx.freqSorted.data());
                 const Eigen::Index lo = hi - 1;
-                const double f0 = f_sorted(lo), f1 = f_sorted(hi);
-                const double t  = (fb - f0) / (f1 - f0 + 1e-30);
-                const std::complex<double> y0 = s11_sorted(lo);
-                const std::complex<double> y1 = s11_sorted(hi);
-                S11_bins(i) = y0 + (y1 - y0) * t;
+                const double f0 = ctx.freqSorted(lo);
+                const double f1 = ctx.freqSorted(hi);
+                const double t = (fb - f0) / (f1 - f0 + 1e-30);
+                const std::complex<double> y0 = ctx.reflectionSorted(lo);
+                const std::complex<double> y1 = ctx.reflectionSorted(hi);
+                ctx.spectrumPositive(static_cast<Eigen::Index>(i)) = y0 + (y1 - y0) * t;
             }
         }
     }
 
-    // === Optional filter (safe) ===
-    if (params.risetime > 0.0 && params.filter != Parameters::FilterType::None) {
+    if (params.risetime > 0.0 && params.filter != TDRCalculator::Parameters::FilterType::None) {
         const double fc = 0.35 / params.risetime;
         for (std::size_t i = 0; i < nBins; ++i) {
-            const double fcur = f_bins(i);
+            const double fcur = ctx.freqBins(static_cast<Eigen::Index>(i));
             double H = 1.0;
-            if (params.filter == Parameters::FilterType::Gaussian) {
+            if (params.filter == TDRCalculator::Parameters::FilterType::Gaussian) {
                 H = std::exp(-std::pow(fcur / fc, 2.0));
-            } else if (params.filter == Parameters::FilterType::RaisedCosine) {
+            } else if (params.filter == TDRCalculator::Parameters::FilterType::RaisedCosine) {
                 const double roll = std::clamp(params.rolloff, 0.0, 1.0);
                 const double f0 = (1.0 - roll) * fc;
                 const double f1 = (1.0 + roll) * fc;
@@ -134,87 +156,256 @@ TDRCalculator::Result TDRCalculator::compute(const Eigen::ArrayXd& frequencyHz,
                     H = 0.5 * (1.0 + std::cos(kPi * (fcur - f0) / (2.0 * roll * fc)));
                 }
             }
-            S11_bins(i) *= H;
+            ctx.spectrumPositive(static_cast<Eigen::Index>(i)) *= H;
         }
     }
 
-    // === High-end cosine taper ===
     {
         const int edge = std::max<int>(1, int(0.10 * (nBins - 1)));
-        ApplyHighEndCosineTaper(S11_bins, edge);
+        ApplyHighEndCosineTaper(ctx.spectrumPositive, edge);
     }
 
-    // Build Hermitian spectrum
-    std::vector<std::complex<double>> specFull(Nfft, {0.0, 0.0});
-    for (std::size_t i = 0; i < nBins; ++i) {
-        specFull[i] = S11_bins(i);
-    }
-    for (std::size_t i = 1; i < nBins; ++i) {
-        specFull[Nfft - i] = std::conj(S11_bins(i));
-    }
+    ctx.spectrumFull.assign(ctx.Nfft, std::complex<double>(0.0, 0.0));
+    for (std::size_t i = 0; i < nBins; ++i)
+        ctx.spectrumFull[i] = ctx.spectrumPositive(static_cast<Eigen::Index>(i));
+    for (std::size_t i = 1; i < nBins; ++i)
+        ctx.spectrumFull[ctx.Nfft - i] = std::conj(ctx.spectrumPositive(static_cast<Eigen::Index>(i)));
 
-    // IFFT → impulse response
     Eigen::FFT<double> fft;
-    std::vector<std::complex<double>> timeCmplx(Nfft);
-    fft.inv(timeCmplx, specFull);
+    std::vector<std::complex<double>> timeCmplx(ctx.Nfft);
+    fft.inv(timeCmplx, ctx.spectrumFull);
 
-    Eigen::ArrayXd h(Nfft);
-    for (std::size_t i = 0; i < Nfft; ++i) {
-        h(i) = timeCmplx[i].real();
-    }
+    ctx.impulse.resize(static_cast<int>(ctx.Nfft));
+    for (std::size_t i = 0; i < ctx.Nfft; ++i)
+        ctx.impulse(static_cast<Eigen::Index>(i)) = timeCmplx[i].real();
 
-    // Step response = cumulative sum
-    Eigen::ArrayXd rho(Nfft);
+    const double fmax = ctx.df * double(nBins - 1);
+    const double fs = 2.0 * fmax;
+    ctx.dt = (fs > 0.0) ? (1.0 / fs) : 0.0;
+    const double erEff = safeEpsilon(params.effectivePermittivity);
+    ctx.velocity = kC0 / std::sqrt(erEff);
+
+    return ctx;
+}
+
+Eigen::ArrayXd ComputeStepResponse(const Eigen::ArrayXd& impulse)
+{
+    Eigen::ArrayXd rho(impulse.size());
     double acc = 0.0;
-    for (std::size_t i = 0; i < Nfft; ++i) {
-        acc += h(i);
+    for (Eigen::Index i = 0; i < impulse.size(); ++i) {
+        acc += impulse(i);
         rho(i) = acc;
     }
+    return rho;
+}
 
-    // Baseline correction
-    {
-        const std::size_t k = std::min<std::size_t>(Nfft, 64);
-        double base = 0.0;
-        for (std::size_t i = 0; i < k; ++i) base += rho(i);
-        base /= double(k);
-        for (std::size_t i = 0; i < Nfft; ++i) rho(i) -= base;
-    }
+void BaselineCorrect(Eigen::ArrayXd& rho)
+{
+    const std::size_t count = static_cast<std::size_t>(rho.size());
+    const std::size_t k = std::min<std::size_t>(count, 64);
+    double base = 0.0;
+    for (std::size_t i = 0; i < k; ++i)
+        base += rho(static_cast<Eigen::Index>(i));
+    base /= double(k);
+    for (std::size_t i = 0; i < count; ++i)
+        rho(static_cast<Eigen::Index>(i)) -= base;
+}
 
-    // Clamp
-    for (std::size_t i = 0; i < Nfft; ++i) {
+void ClampStep(Eigen::ArrayXd& rho)
+{
+    for (Eigen::Index i = 0; i < rho.size(); ++i) {
         if (rho(i) > 0.999) rho(i) = 0.999;
         if (rho(i) < -0.999) rho(i) = -0.999;
     }
+}
 
-    // Convert to impedance
-    const double Z0 = params.referenceImpedance;
-    Eigen::ArrayXd Z(Nfft);
-    for (std::size_t i = 0; i < Nfft; ++i) {
+Eigen::ArrayXd StepToImpedance(const Eigen::ArrayXd& rho, double referenceImpedance)
+{
+    Eigen::ArrayXd Z(rho.size());
+    for (Eigen::Index i = 0; i < rho.size(); ++i) {
         const double g = rho(i);
         const double den = 1.0 - g;
         if (std::abs(den) < 1e-14) {
             Z(i) = std::numeric_limits<double>::quiet_NaN();
         } else {
-            Z(i) = Z0 * (1.0 + g) / den;
+            Z(i) = referenceImpedance * (1.0 + g) / den;
+        }
+    }
+    return Z;
+}
+
+QVector<double> DistanceVector(std::size_t Nfft, double dt, double velocity)
+{
+    QVector<double> distance(static_cast<int>(Nfft));
+    for (std::size_t i = 0; i < Nfft; ++i) {
+        const double t = dt * double(i);
+        distance[static_cast<int>(i)] = 0.5 * velocity * t;
+    }
+    return distance;
+}
+
+Eigen::ArrayXcd MapSpectrumToOriginal(const TransformContext& ctx,
+                                      const Eigen::ArrayXcd& positiveSpectrum)
+{
+    const Eigen::Index m = ctx.freqSorted.size();
+    Eigen::ArrayXcd sortedValues(m);
+    const double df = ctx.df;
+    if (!(df > 0.0) || positiveSpectrum.size() == 0)
+        return Eigen::ArrayXcd::Zero(m);
+
+    const Eigen::Index lastIndex = positiveSpectrum.size() - 1;
+    for (Eigen::Index i = 0; i < m; ++i) {
+        const double f = ctx.freqSorted(i);
+        double pos = f / df;
+        if (pos <= 0.0) {
+            sortedValues(i) = positiveSpectrum(0);
+            continue;
+        }
+        const double floorIndex = std::floor(pos);
+        Eigen::Index idx0 = static_cast<Eigen::Index>(floorIndex);
+        Eigen::Index idx1 = idx0 + 1;
+        double frac = pos - floorIndex;
+        if (idx0 < 0) {
+            sortedValues(i) = positiveSpectrum(0);
+        } else if (idx0 >= lastIndex) {
+            sortedValues(i) = positiveSpectrum(lastIndex);
+        } else {
+            if (idx1 > lastIndex) {
+                idx1 = lastIndex;
+                frac = 0.0;
+            }
+            sortedValues(i) = (1.0 - frac) * positiveSpectrum(idx0) + frac * positiveSpectrum(idx1);
         }
     }
 
-    // Time and distance axes
-    const double fmax = df_est * double(nBins - 1);
-    const double fs   = 2.0 * fmax;
-    const double dt   = (fs > 0.0) ? (1.0 / fs) : 0.0;
-
-    const double er_eff = std::max(params.effectivePermittivity, 1.0);
-    const double v = kC0 / std::sqrt(er_eff);
-
-    result.distance.reserve(static_cast<int>(Nfft));
-    result.impedance.reserve(static_cast<int>(Nfft));
-    for (std::size_t i = 0; i < Nfft; ++i) {
-        const double t  = dt * double(i);
-        const double d  = 0.5 * v * t; // round-trip
-        result.distance.append(d);
-        result.impedance.append(Z(i));
+    Eigen::ArrayXcd result(m);
+    for (Eigen::Index i = 0; i < m; ++i) {
+        const int originalIndex = ctx.permutation[static_cast<std::size_t>(i)];
+        result(originalIndex) = sortedValues(i);
     }
+    return result;
+}
+
+Eigen::ArrayXd GateWindow(std::size_t size, double dt, double velocity,
+                          double startDistance, double stopDistance)
+{
+    Eigen::ArrayXd window = Eigen::ArrayXd::Zero(static_cast<Eigen::Index>(size));
+    if (size == 0 || !(dt > 0.0) || !(velocity > 0.0))
+        return window;
+
+    const double startDist = std::max(0.0, startDistance);
+    const double stopDist = std::max(startDist, stopDistance);
+
+    const double startTime = 2.0 * startDist / velocity;
+    const double stopTime = 2.0 * stopDist / velocity;
+
+    int startIndex = static_cast<int>(std::floor(startTime / dt));
+    int stopIndex = static_cast<int>(std::ceil(stopTime / dt));
+
+    const int last = static_cast<int>(size) - 1;
+    if (startIndex > last) startIndex = last;
+    if (stopIndex > last) stopIndex = last;
+    if (startIndex < 0) startIndex = 0;
+    if (stopIndex < startIndex) stopIndex = startIndex;
+
+    if (startIndex == 0 && stopIndex == last) {
+        window.setOnes();
+        return window;
+    }
+
+    const int width = stopIndex - startIndex + 1;
+    if (width <= 1) {
+        window(startIndex) = 1.0;
+        return window;
+    }
+
+    const double alpha = 0.3;
+    const double usedAlpha = std::clamp(alpha, 0.0, 1.0);
+    const double boundary = usedAlpha / 2.0;
+    const double denom = double(width - 1);
+
+    for (int n = 0; n < width; ++n) {
+        double ratio = (denom > 0.0) ? (double(n) / denom) : 0.0;
+        double weight = 1.0;
+        if (usedAlpha > 0.0) {
+            if (ratio < boundary) {
+                weight = 0.5 * (1.0 + std::cos(kPi * ((2.0 * ratio / usedAlpha) - 1.0)));
+            } else if (ratio > 1.0 - boundary) {
+                weight = 0.5 * (1.0 + std::cos(kPi * ((2.0 * ratio / usedAlpha) - (2.0 / usedAlpha) + 1.0)));
+            }
+        }
+        window(startIndex + n) = weight;
+    }
+
+    return window;
+}
+
+} // namespace
+
+TDRCalculator::Result TDRCalculator::compute(const Eigen::ArrayXd& frequencyHz,
+                                             const Eigen::ArrayXcd& reflection,
+                                             const Parameters& params) const
+{
+    Result result;
+
+    auto ctxOpt = PrepareTransform(frequencyHz, reflection, params);
+    if (!ctxOpt)
+        return result;
+
+    TransformContext& ctx = *ctxOpt;
+
+    Eigen::ArrayXd rho = ComputeStepResponse(ctx.impulse);
+    BaselineCorrect(rho);
+    ClampStep(rho);
+    Eigen::ArrayXd impedance = StepToImpedance(rho, params.referenceImpedance);
+
+    result.distance = DistanceVector(ctx.Nfft, ctx.dt, ctx.velocity);
+    result.impedance = QVector<double>(impedance.data(), impedance.data() + impedance.size());
+
+    return result;
+}
+
+std::optional<TDRCalculator::GateResult> TDRCalculator::applyGate(const Eigen::ArrayXd& frequencyHz,
+                                                                  const Eigen::ArrayXcd& reflection,
+                                                                  double gateStartDistance,
+                                                                  double gateStopDistance,
+                                                                  double epsilonR,
+                                                                  const Parameters& params) const
+{
+    Parameters gateParams = params;
+    gateParams.effectivePermittivity = safeEpsilon(epsilonR);
+
+    auto ctxOpt = PrepareTransform(frequencyHz, reflection, gateParams);
+    if (!ctxOpt)
+        return std::nullopt;
+
+    TransformContext ctx = *ctxOpt;
+
+    Eigen::ArrayXd window = GateWindow(ctx.Nfft, ctx.dt, ctx.velocity,
+                                       gateStartDistance, gateStopDistance);
+    if (window.size() != ctx.impulse.size()) {
+        window.conservativeResize(ctx.impulse.size());
+    }
+
+    Eigen::ArrayXd gatedImpulse = ctx.impulse * window;
+
+    Eigen::ArrayXd rho = ComputeStepResponse(gatedImpulse);
+    BaselineCorrect(rho);
+    ClampStep(rho);
+    Eigen::ArrayXd impedance = StepToImpedance(rho, gateParams.referenceImpedance);
+
+    Eigen::FFT<double> fft;
+    std::vector<std::complex<double>> specFull(ctx.Nfft);
+    fft.fwd(specFull, gatedImpulse);
+
+    Eigen::ArrayXcd positive(ctx.freqBins.size());
+    for (Eigen::Index i = 0; i < positive.size(); ++i)
+        positive(i) = specFull[static_cast<std::size_t>(i)];
+
+    GateResult result;
+    result.gatedReflection = MapSpectrumToOriginal(ctx, positive);
+    result.distance = DistanceVector(ctx.Nfft, ctx.dt, ctx.velocity);
+    result.impedance = QVector<double>(impedance.data(), impedance.data() + impedance.size());
 
     return result;
 }

--- a/tdrcalculator.h
+++ b/tdrcalculator.h
@@ -4,6 +4,7 @@
 #include <QVector>
 #include <Eigen/Dense>
 #include <complex>
+#include <optional>
 
 class TDRCalculator
 {
@@ -42,9 +43,23 @@ public:
         QVector<double> impedance;
     };
 
+    struct GateResult
+    {
+        Eigen::ArrayXcd gatedReflection;
+        QVector<double> distance;
+        QVector<double> impedance;
+    };
+
     Result compute(const Eigen::ArrayXd& frequencyHz,
                    const Eigen::ArrayXcd& reflection,
                    const Parameters& params = Parameters()) const;
+
+    std::optional<GateResult> applyGate(const Eigen::ArrayXd& frequencyHz,
+                                        const Eigen::ArrayXcd& reflection,
+                                        double gateStartDistance,
+                                        double gateStopDistance,
+                                        double epsilonR,
+                                        const Parameters& params = Parameters()) const;
 };
 
 #endif // TDRCALCULATOR_H


### PR DESCRIPTION
## Summary
- add shared time-domain transform helpers and a new `applyGate` API in `TDRCalculator` to gate reflection data before returning to frequency domain
- store global gate settings in `Network` and expose UI controls in `MainWindow`, including wheel-adjustable start/stop fields and epsilon handling
- apply the gated reflection data to file, lumped, and cascade networks so magnitude/phase/VSWR/Smith/TDR plots honour the active gate

## Testing
- ./build.sh *(fails: Qt6 pkg-config files missing in environment)*
- ./test.sh *(fails: Qt6 pkg-config files missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0653ea18c832684b876d6bc8ebf9d