### PR TITLE
Install Qt and Python dependencies for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ CMakeLists.txt.user*
 .rcc/
 .uic/
 /build*/
+tests/artifacts/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ QT_QPA_PLATFORM=offscreen ./fsnpview /path/to/your/file.s2p
 
 ## Testing
 
-Run `./build.sh` followed by `./test.sh` to execute unit tests, including an offscreen GUI plot comparison against the baseline `tests/gui_plot_baseline.csv`.
+Run `./setup.sh` first to install the required system and Python dependencies (the script uses `sudo`).
+After the dependencies are available, `./test.sh` builds the application and executes the full test suite, including the offscreen GUI plot comparison against the baseline `tests/gui_plot_baseline.csv` and the regression test that checks the lumped-network models against scikit-rf.
 To update the baseline after intentional changes, rebuild and run:
 
 ```bash

--- a/fsnpview.pro
+++ b/fsnpview.pro
@@ -4,6 +4,10 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
 
 #add console for debug outputs with release
 CONFIG += c++17
+
+unix {
+    CONFIG += no_include_pwd
+}
 #CONFIG += console
 
 # remove possible other optimization flags

--- a/main.cpp
+++ b/main.cpp
@@ -181,15 +181,17 @@ int runNoGui(const CommandLineParser::Options& options)
 
     Eigen::VectorXd freq = buildFrequencyVector(options, cascade);
 
+    int exitCode = 0;
     if (options.saveRequested) {
         if (!saveCascadeToFile(cascade, freq, options.savePath))
-            return 1;
+            exitCode = 1;
     } else {
         std::cout << "Cascade configured with " << cascade.getNetworks().size()
                   << " network(s)." << std::endl;
     }
 
-    return 0;
+    cascade.clearNetworks();
+    return exitCode;
 }
 
 QStringList collectFilesToOpen(const CommandLineParser::Options& options)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+matplotlib
+scikit-rf

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # This script installs the dependencies for the fsnpview project on Debian-based systems.
 set -e
-sudo apt-get update && sudo apt-get install -y build-essential qt6-base-dev qt6-base-dev-tools libeigen3-dev
+sudo apt-get update
+sudo apt-get install -y build-essential qt6-base-dev qt6-base-dev-tools libeigen3-dev python3-pip
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade -r requirements-test.txt

--- a/test.sh
+++ b/test.sh
@@ -5,8 +5,13 @@ set -e
 
 ./build.sh
 
+qmake6
+make -j"$(nproc)"
+
 ./parser_touchstone_tests
 ./tdrcalculator_tests
 QT_QPA_PLATFORM=offscreen ./gui_plot_tests
 ./networkcascade_tests
+
+python3 tests/test_lumped_networks_cli_vs_skrf.py
 

--- a/tests/test_lumped_networks_cli_vs_skrf.py
+++ b/tests/test_lumped_networks_cli_vs_skrf.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Compare fsnpview lumped networks against scikit-rf implementations."""
+from __future__ import annotations
+
+import math
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import skrf as rf
+from skrf.media import DefinedGammaZ0
+
+C0 = 299_792_458.0
+Z0_REFERENCE = 50.0
+FMIN_HZ = 1e6
+FMAX_HZ = 10e9
+FREQ_POINTS = 501
+MIN_MAGNITUDE = 1e-30
+PLOT_S_PARAMETERS: Sequence[tuple[int, int]] = ((0, 0), (1, 0), (0, 1), (1, 1))
+
+
+@dataclass(frozen=True)
+class LumpedNetworkSpec:
+    name: str
+    cli_tokens: list[str]
+    build_expected: Callable[[Callable[[float], DefinedGammaZ0]], rf.Network]
+
+
+def rename_network(network: rf.Network, name: str) -> rf.Network:
+    copy = network.copy()
+    copy.name = name
+    return copy
+
+
+def build_series_rl(media: DefinedGammaZ0, inductance_h: float, resistance_ohm: float, base_name: str) -> rf.Network:
+    resistor = rename_network(media.resistor(resistance_ohm), f"{base_name}_res")
+    inductor = rename_network(media.inductor(inductance_h), f"{base_name}_ind")
+    series = resistor ** inductor
+    series = rename_network(series, base_name)
+    return series
+
+
+def build_shunt_rl(media: DefinedGammaZ0, inductance_h: float, resistance_ohm: float, base_name: str) -> rf.Network:
+    series_branch = build_series_rl(media, inductance_h, resistance_ohm, f"{base_name}_series")
+    short = rename_network(media.short(), f"{base_name}_short")
+    terminated = series_branch ** short
+    terminated = rename_network(terminated, f"{base_name}_terminated")
+    shunted = media.shunt(terminated)
+    shunted = rename_network(shunted, base_name)
+    return shunted
+
+
+def wrap_phase_deg(values: np.ndarray) -> np.ndarray:
+    """Wrap phase values to [-180, 180) degrees."""
+    return (values + 180.0) % 360.0 - 180.0
+
+
+def amplitude_db(values: np.ndarray) -> np.ndarray:
+    return 20.0 * np.log10(np.maximum(np.abs(values), MIN_MAGNITUDE))
+
+
+def format_frequency_axis(freq_hz: np.ndarray) -> np.ndarray:
+    return freq_hz / 1e9
+
+
+def create_artifact_dir(root: Path) -> Path:
+    artifact_dir = root / "tests" / "artifacts" / "lumped_networks"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    for path in artifact_dir.glob("*"):
+        if path.is_file():
+            path.unlink()
+    return artifact_dir
+
+
+def run_fsnpview(
+    binary: Path,
+    cascade_tokens: Sequence[str],
+    save_path: Path,
+    *,
+    env: dict[str, str],
+    cwd: Path,
+) -> None:
+    command = [
+        str(binary),
+        "--nogui",
+        "--freq",
+        f"{FMIN_HZ}",
+        f"{FMAX_HZ}",
+        str(FREQ_POINTS),
+        "--cascade",
+        *cascade_tokens,
+        "--save",
+        str(save_path),
+    ]
+    subprocess.run(command, check=True, cwd=cwd, env=env)
+
+
+def plot_comparison(
+    network_name: str,
+    freq_hz: np.ndarray,
+    cli_network: rf.Network,
+    expected_network: rf.Network,
+    artifact_dir: Path,
+) -> None:
+    freq_ghz = format_frequency_axis(freq_hz)
+    amplitude_fig, amplitude_axes = plt.subplots(len(PLOT_S_PARAMETERS), 2, figsize=(14, 12), sharex=True)
+    phase_fig, phase_axes = plt.subplots(len(PLOT_S_PARAMETERS), 2, figsize=(14, 12), sharex=True)
+
+    for row_index, (i, j) in enumerate(PLOT_S_PARAMETERS):
+        cli_s = cli_network.s[:, i, j]
+        expected_s = expected_network.s[:, i, j]
+
+        cli_amp = amplitude_db(cli_s)
+        expected_amp = amplitude_db(expected_s)
+        amp_diff = cli_amp - expected_amp
+
+        cli_phase = np.angle(cli_s, deg=True)
+        expected_phase = np.angle(expected_s, deg=True)
+        phase_diff = wrap_phase_deg(cli_phase - expected_phase)
+
+        ax_amp = amplitude_axes[row_index, 0]
+        ax_amp.plot(freq_ghz, cli_amp, label="fsnpview")
+        ax_amp.plot(freq_ghz, expected_amp, label="scikit-rf", linestyle="--")
+        ax_amp.set_ylabel(f"S{ i + 1 }{ j + 1 } (dB)")
+        ax_amp.grid(True, which="both")
+        if row_index == 0:
+            ax_amp.set_title("Amplitude comparison")
+
+        ax_amp_diff = amplitude_axes[row_index, 1]
+        ax_amp_diff.plot(freq_ghz, amp_diff, color="tab:red")
+        ax_amp_diff.set_ylabel(f"ΔS{ i + 1 }{ j + 1 } (dB)")
+        ax_amp_diff.grid(True, which="both")
+        if row_index == 0:
+            ax_amp_diff.set_title("Amplitude difference")
+
+        ax_phase = phase_axes[row_index, 0]
+        ax_phase.plot(freq_ghz, cli_phase, label="fsnpview")
+        ax_phase.plot(freq_ghz, expected_phase, label="scikit-rf", linestyle="--")
+        ax_phase.set_ylabel(f"S{ i + 1 }{ j + 1 } (deg)")
+        ax_phase.grid(True, which="both")
+        if row_index == 0:
+            ax_phase.set_title("Phase comparison")
+
+        ax_phase_diff = phase_axes[row_index, 1]
+        ax_phase_diff.plot(freq_ghz, phase_diff, color="tab:purple")
+        ax_phase_diff.set_ylabel(f"ΔS{ i + 1 }{ j + 1 } (deg)")
+        ax_phase_diff.grid(True, which="both")
+        if row_index == 0:
+            ax_phase_diff.set_title("Phase difference")
+
+    for axes in (amplitude_axes, phase_axes):
+        axes[-1, 0].set_xlabel("Frequency (GHz)")
+        axes[-1, 1].set_xlabel("Frequency (GHz)")
+
+    handles, labels = amplitude_axes[0, 0].get_legend_handles_labels()
+    if handles:
+        amplitude_fig.legend(handles, labels, loc="upper center", ncol=2)
+    handles, labels = phase_axes[0, 0].get_legend_handles_labels()
+    if handles:
+        phase_fig.legend(handles, labels, loc="upper center", ncol=2)
+
+    amplitude_fig.tight_layout(rect=(0, 0, 1, 0.96))
+    phase_fig.tight_layout(rect=(0, 0, 1, 0.96))
+
+    amplitude_fig.savefig(artifact_dir / f"{network_name}_amplitude.png", dpi=200)
+    phase_fig.savefig(artifact_dir / f"{network_name}_phase.png", dpi=200)
+    plt.close(amplitude_fig)
+    plt.close(phase_fig)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    binary = repo_root / "fsnpview"
+    if not binary.exists():
+        print("fsnpview binary not found. Build the project before running this test.", file=sys.stderr)
+        return 1
+
+    artifact_dir = create_artifact_dir(repo_root)
+
+    freq_values = np.linspace(FMIN_HZ, FMAX_HZ, FREQ_POINTS)
+    frequency = rf.Frequency.from_f(freq_values, unit="hz")
+    gamma = 1j * 2.0 * math.pi * freq_values / C0
+
+    def make_media(z0: float = Z0_REFERENCE) -> DefinedGammaZ0:
+        return DefinedGammaZ0(frequency=frequency, z0=z0, z0_port=Z0_REFERENCE, gamma=gamma)
+
+    specs: list[LumpedNetworkSpec] = [
+        LumpedNetworkSpec(
+            name="R_series",
+            cli_tokens=["R_series", "R", "75.0"],
+            build_expected=lambda factory: rename_network(factory().resistor(75.0), "R_series_expected"),
+        ),
+        LumpedNetworkSpec(
+            name="R_shunt",
+            cli_tokens=["R_shunt", "R", "30.0"],
+            build_expected=lambda factory: rename_network(factory().shunt_resistor(30.0), "R_shunt_expected"),
+        ),
+        LumpedNetworkSpec(
+            name="C_series",
+            cli_tokens=["C_series", "C", "2.2"],
+            build_expected=lambda factory: rename_network(factory().capacitor(2.2e-12), "C_series_expected"),
+        ),
+        LumpedNetworkSpec(
+            name="C_shunt",
+            cli_tokens=["C_shunt", "C", "4.7"],
+            build_expected=lambda factory: rename_network(factory().shunt_capacitor(4.7e-12), "C_shunt_expected"),
+        ),
+        LumpedNetworkSpec(
+            name="L_series",
+            cli_tokens=["L_series", "L", "8.2", "R_ser", "0.75"],
+            build_expected=lambda factory: rename_network(
+                build_series_rl(factory(), 8.2e-9, 0.75, "L_series_expected"),
+                "L_series_expected",
+            ),
+        ),
+        LumpedNetworkSpec(
+            name="L_shunt",
+            cli_tokens=["L_shunt", "L", "12.0", "R_ser", "0.25"],
+            build_expected=lambda factory: rename_network(
+                build_shunt_rl(factory(), 12e-9, 0.25, "L_shunt_expected"),
+                "L_shunt_expected",
+            ),
+        ),
+        LumpedNetworkSpec(
+            name="TransmissionLine",
+            cli_tokens=["TransmissionLine", "len", "0.015", "z0", "60.0"],
+            build_expected=lambda factory: rename_network(
+                factory(60.0).line(d=0.015, unit="m", z0=60.0),
+                "TransmissionLine_expected",
+            ),
+        ),
+    ]
+
+    env = os.environ.copy()
+    env.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    success = True
+
+    for spec in specs:
+        s2p_path = artifact_dir / f"{spec.name}.s2p"
+        run_fsnpview(binary, spec.cli_tokens, s2p_path, env=env, cwd=repo_root)
+        cli_network = rf.Network(str(s2p_path))
+        expected_network = spec.build_expected(make_media)
+
+        if cli_network.frequency != expected_network.frequency:
+            cli_network = cli_network.interpolate(expected_network.frequency, kind="linear")
+
+        diff = cli_network.s - expected_network.s
+        max_abs_error = float(np.max(np.abs(diff)))
+
+        amp_diff = amplitude_db(cli_network.s) - amplitude_db(expected_network.s)
+        max_amp_error = float(np.nanmax(np.abs(amp_diff)))
+
+        phase_diff = wrap_phase_deg(np.angle(cli_network.s, deg=True) - np.angle(expected_network.s, deg=True))
+        max_phase_error = float(np.nanmax(np.abs(phase_diff)))
+
+        print(
+            f"{spec.name}: max |ΔS| = {max_abs_error:.3e}, "
+            f"max |Δmag| = {max_amp_error:.3e} dB, max |Δphase| = {max_phase_error:.3e}°"
+        )
+
+        tolerance = 1e-9
+        if max_abs_error > tolerance:
+            success = False
+            print(f"  ERROR: Difference exceeds tolerance of {tolerance:g}.", file=sys.stderr)
+
+        plot_comparison(spec.name, freq_values, cli_network, expected_network, artifact_dir)
+
+    if not success:
+        return 1
+
+    print(f"Plots saved to {artifact_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- update the qmake project to drop the default include path on Unix so the build uses the system Eigen headers
- teach the headless cascade runner to release its networks after saving so the CLI no longer crashes
- add a Python requirements file, expand `setup.sh`, document the dependency step in the README, and rebuild the app from `test.sh`

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68d31b7ab7bc8326ab86691f961dff6f