### PR TITLE
Fix Windows executable detection in lumped networks test

### DIFF
--- a/tests/test_lumped_networks_cli_vs_skrf.py
+++ b/tests/test_lumped_networks_cli_vs_skrf.py
@@ -178,8 +178,18 @@ def plot_comparison(
 
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[1]
-    binary = repo_root / "fsnpview"
-    if not binary.exists():
+    binary_candidates: list[Path] = []
+    if sys.platform.startswith("win"):
+        binary_candidates.append(repo_root / "fsnpview.exe")
+    binary_candidates.append(repo_root / "fsnpview")
+    if not sys.platform.startswith("win"):
+        binary_candidates.append(repo_root / "fsnpview.exe")
+
+    for candidate in binary_candidates:
+        if candidate.exists():
+            binary = candidate
+            break
+    else:
         print("fsnpview binary not found. Build the project before running this test.", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
## Summary
- update the lumped networks CLI vs scikit-rf test to prefer the Windows fsnpview.exe binary when available
- retain support for the Unix-style fsnpview binary as a fallback

## Testing
- python -m compileall tests/test_lumped_networks_cli_vs_skrf.py

------
https://chatgpt.com/codex/tasks/task_e_68d442970cbc8326a95c1ab9ee22e746