### PR TITLE
Add UI control for phase unwrap toggle

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -60,6 +60,7 @@ private slots:
     void on_checkBoxS33_checkStateChanged(const Qt::CheckState &arg1);
 
     void on_checkBoxPhase_checkStateChanged(const Qt::CheckState &arg1);
+    void on_checkBoxPhaseUnwrap_stateChanged(int state);
     void on_checkBoxVSWR_checkStateChanged(const Qt::CheckState &arg1);
     void on_checkBoxSmith_checkStateChanged(const Qt::CheckState &arg1);
     void on_checkBoxTDR_checkStateChanged(const Qt::CheckState &arg1);
@@ -99,6 +100,7 @@ private:
     bool applyGateSettingsFromUi();
     void refreshGateControls();
     static bool nearlyEqual(double lhs, double rhs);
+    void applyPhaseUnwrapSetting(bool unwrap);
 
 
     Ui::MainWindow *ui;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -259,6 +259,16 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="checkBoxPhaseUnwrap">
+              <property name="text">
+               <string>Unwrap</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="checkBoxVSWR">
               <property name="text">
                <string>VSWR</string>

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <complex>
 #include <iostream>
+#include <cmath>
 
 void test_cascade_two_files()
 {
@@ -40,9 +41,34 @@ void test_cascade_two_files()
     assert(close(s[3], s22_expected));
 }
 
+void test_phase_unwrap_toggle()
+{
+    NetworkFile net(QStringLiteral("test/a (1).s2p"));
+
+    net.setUnwrapPhase(true);
+    const auto unwrapped = net.getPlotData(0, PlotType::Phase);
+
+    net.setUnwrapPhase(false);
+    const auto wrapped = net.getPlotData(0, PlotType::Phase);
+
+    assert(!wrapped.second.isEmpty());
+    assert(unwrapped.second.size() == wrapped.second.size());
+
+    bool differenceFound = false;
+    for (int i = 0; i < wrapped.second.size(); ++i) {
+        if (std::abs(unwrapped.second[i] - wrapped.second[i]) > 1e-3) {
+            differenceFound = true;
+            break;
+        }
+    }
+
+    assert(differenceFound);
+}
+
 int main()
 {
     test_cascade_two_files();
+    test_phase_unwrap_toggle();
     std::cout << "All NetworkCascade tests passed." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a new "Unwrap" checkbox next to the phase plot toggle and default it to enabled
- propagate the unwrap setting to all loaded networks and the cascade whenever data changes or the checkbox is toggled
- extend the network cascade test suite to verify that toggling phase unwrapping affects the plotted phase data

## Testing
- ./test.sh *(fails: Qt6 pkg-config files are unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d462e2ad088326a3bd2c94f2d0fa5a