### PR TITLE
Fix phase unwrapping for lumped and cascaded networks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,5 +32,6 @@ g++ -std=c++17 -I/usr/include/eigen3 -I. \
 
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
     tests/networkcascade_tests.cpp parser_touchstone.cpp network.cpp networkfile.cpp \
-    networkcascade.cpp tdrcalculator.cpp moc_network.cpp moc_networkfile.cpp moc_networkcascade.cpp \
+    networklumped.cpp networkcascade.cpp tdrcalculator.cpp \
+    moc_network.cpp moc_networkfile.cpp moc_networklumped.cpp moc_networkcascade.cpp \
     -o networkcascade_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)

--- a/networkcascade.cpp
+++ b/networkcascade.cpp
@@ -177,10 +177,11 @@ QPair<QVector<double>, QVector<double>> NetworkCascade::getPlotData(int s_param_
         return qMakePair(freqVector, values);
     }
     case PlotType::Phase: {
-        Eigen::ArrayXd phase = sparam.arg() * 180.0 / pi;
+        Eigen::ArrayXd phase_rad = sparam.arg();
         if (m_unwrap_phase)
-            phase = unwrap(phase);
-        QVector<double> values(phase.data(), phase.data() + phase.size());
+            phase_rad = unwrap(phase_rad);
+        Eigen::ArrayXd phase_deg = phase_rad * (180.0 / pi);
+        QVector<double> values(phase_deg.data(), phase_deg.data() + phase_deg.size());
         return qMakePair(freqVector, values);
     }
     case PlotType::VSWR: {

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -288,10 +288,11 @@ QPair<QVector<double>, QVector<double>> NetworkLumped::getPlotData(int s_param_i
         return qMakePair(freqVector, values);
     }
     case PlotType::Phase: {
-        Eigen::ArrayXd phase = sparam.arg() * 180.0 / pi;
+        Eigen::ArrayXd phase_rad = sparam.arg();
         if (m_unwrap_phase)
-            phase = unwrap(phase);
-        QVector<double> values(phase.data(), phase.data() + phase.size());
+            phase_rad = unwrap(phase_rad);
+        Eigen::ArrayXd phase_deg = phase_rad * (180.0 / pi);
+        QVector<double> values(phase_deg.data(), phase_deg.data() + phase_deg.size());
         return qMakePair(freqVector, values);
     }
     case PlotType::VSWR: {

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -1,5 +1,6 @@
 #include "networkcascade.h"
 #include "networkfile.h"
+#include "networklumped.h"
 #include <Eigen/Dense>
 #include <cassert>
 #include <complex>
@@ -41,6 +42,30 @@ void test_cascade_two_files()
     assert(close(s[3], s22_expected));
 }
 
+namespace {
+constexpr double pi = 3.14159265358979323846;
+
+Eigen::ArrayXd unwrap_degrees(const QVector<double>& phase_deg)
+{
+    if (phase_deg.isEmpty())
+        return {};
+
+    Eigen::ArrayXd phase_rad = Eigen::Map<const Eigen::ArrayXd>(phase_deg.constData(), phase_deg.size()) * (pi / 180.0);
+    Eigen::ArrayXd unwrapped = phase_rad;
+    for (int i = 1; i < unwrapped.size(); ++i) {
+        double diff = unwrapped(i) - unwrapped(i - 1);
+        if (diff > pi) {
+            for (int j = i; j < unwrapped.size(); ++j)
+                unwrapped(j) -= 2.0 * pi;
+        } else if (diff < -pi) {
+            for (int j = i; j < unwrapped.size(); ++j)
+                unwrapped(j) += 2.0 * pi;
+        }
+    }
+    return unwrapped * (180.0 / pi);
+}
+}
+
 void test_phase_unwrap_toggle()
 {
     NetworkFile net(QStringLiteral("test/a (1).s2p"));
@@ -65,10 +90,68 @@ void test_phase_unwrap_toggle()
     assert(differenceFound);
 }
 
+void test_lumped_phase_unwrap_matches_manual()
+{
+    NetworkLumped transmissionLine(NetworkLumped::NetworkType::TransmissionLine,
+                                   {100.0, 50.0, 2.5});
+
+    transmissionLine.setUnwrapPhase(false);
+    const auto wrapped = transmissionLine.getPlotData(0, PlotType::Phase);
+
+    transmissionLine.setUnwrapPhase(true);
+    const auto unwrapped = transmissionLine.getPlotData(0, PlotType::Phase);
+
+    assert(unwrapped.second.size() == wrapped.second.size());
+    Eigen::ArrayXd manual = unwrap_degrees(wrapped.second);
+
+    bool differenceFound = false;
+    for (int i = 0; i < wrapped.second.size(); ++i) {
+        double expected = manual(i);
+        double actual = unwrapped.second[i];
+        assert(std::abs(actual - expected) <= 1e-6);
+        if (std::abs(actual - wrapped.second[i]) > 1e-3)
+            differenceFound = true;
+    }
+
+    assert(differenceFound);
+}
+
+void test_cascade_phase_unwrap_matches_manual()
+{
+    NetworkLumped section1(NetworkLumped::NetworkType::TransmissionLine, {50.0, 50.0, 3.0});
+    NetworkLumped section2(NetworkLumped::NetworkType::TransmissionLine, {75.0, 50.0, 2.5});
+
+    NetworkCascade cascade;
+    cascade.addNetwork(&section1);
+    cascade.addNetwork(&section2);
+
+    cascade.setUnwrapPhase(false);
+    const auto wrapped = cascade.getPlotData(0, PlotType::Phase);
+
+    cascade.setUnwrapPhase(true);
+    const auto unwrapped = cascade.getPlotData(0, PlotType::Phase);
+
+    assert(unwrapped.second.size() == wrapped.second.size());
+    Eigen::ArrayXd manual = unwrap_degrees(wrapped.second);
+
+    bool differenceFound = false;
+    for (int i = 0; i < wrapped.second.size(); ++i) {
+        double expected = manual(i);
+        double actual = unwrapped.second[i];
+        assert(std::abs(actual - expected) <= 1e-6);
+        if (std::abs(actual - wrapped.second[i]) > 1e-3)
+            differenceFound = true;
+    }
+
+    assert(differenceFound);
+}
+
 int main()
 {
     test_cascade_two_files();
     test_phase_unwrap_toggle();
+    test_lumped_phase_unwrap_matches_manual();
+    test_cascade_phase_unwrap_matches_manual();
     std::cout << "All NetworkCascade tests passed." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- keep phase unwrapping in radians for lumped and cascaded network plots before converting to degrees
- extend cascade test suite to cover lumped and cascaded phase unwrapping results
- update build script so the cascade tests link against the lumped network implementation

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68d5a21dc578832682374d63db68dd09