### PR TITLE
Add frequency controls for lumped and cascade networks

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -154,8 +154,7 @@ int runNoGui(const CommandLineParser::Options& options)
 
     NetworkCascade cascade;
     if (options.freqSpecified) {
-        cascade.setFmin(options.fmin);
-        cascade.setFmax(options.fmax);
+        cascade.setFrequencyRange(options.fmin, options.fmax);
         cascade.setPointCount(options.freqPoints);
     }
 
@@ -312,6 +311,12 @@ int main(int argc, char *argv[])
     if (!filesToOpen.isEmpty()) {
         window.processFiles(filesToOpen, true);
     }
+
+    window.initializeFrequencyControls(options.freqSpecified,
+                                       options.fmin,
+                                       options.fmax,
+                                       options.freqPoints,
+                                       !filesToOpen.isEmpty());
 
     if (!configureCascadeForWindow(window, options)) {
 #ifdef Q_OS_WIN

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -59,12 +59,18 @@ MainWindow::MainWindow(QWidget *parent)
     , m_network_cascade_model(new NetworkItemModel(this))
     , m_lumpedParameterCount(0)
     , m_lastSelectionOrigin(SelectionOrigin::None)
+    , m_networkFrequencyMin(0.0)
+    , m_networkFrequencyMax(0.0)
+    , m_networkFrequencyPoints(0)
 {
     ui->setupUi(this);
     m_plot_manager = new PlotManager(ui->widgetGraph, this);
 
     ui->lineEditGateStart->installEventFilter(this);
     ui->lineEditGateStop->installEventFilter(this);
+    ui->lineEditFminNetworks->installEventFilter(this);
+    ui->lineEditFmaxNetworks->installEventFilter(this);
+    ui->lineEditNpointsNetworks->installEventFilter(this);
 
     Network::TimeGateSettings gateSettings;
     gateSettings.enabled = false;
@@ -84,6 +90,8 @@ MainWindow::MainWindow(QWidget *parent)
     setupViews();
     populateLumpedNetworkTable();
     applyPhaseUnwrapSetting(ui->checkBoxPhaseUnwrap->isChecked());
+    updateNetworkFrequencySettings(m_cascade->fmin(), m_cascade->fmax(), m_cascade->pointCount());
+    refreshNetworkFrequencyControls();
     ui->tableViewNetworkLumped->viewport()->installEventFilter(this);
     ui->tableViewCascade->viewport()->installEventFilter(this);
 
@@ -127,8 +135,8 @@ MainWindow::~MainWindow()
 
 void MainWindow::setupModels()
 {
-    m_network_files_model->setColumnCount(3);
-    m_network_files_model->setHorizontalHeaderLabels({"  ", "  ", "File"}); //Plot, Color, File
+    m_network_files_model->setColumnCount(6);
+    m_network_files_model->setHorizontalHeaderLabels({"  ", "  ", "File", "fmin", "fmax", "pts"}); //Plot, Color, File, Range
     connect(m_network_files_model, &QStandardItemModel::itemChanged, this, &MainWindow::onNetworkFilesModelChanged);
 
     m_network_lumped_model->setColumnCount(3);
@@ -300,11 +308,29 @@ void MainWindow::processFiles(const QStringList &files, bool autoscale)
         checkItem->setCheckState(Qt::Checked);
         checkItem->setData(QVariant::fromValue(reinterpret_cast<quintptr>(network)), Qt::UserRole);
         row.append(checkItem);
+
         QStandardItem* colorItem = new QStandardItem();
         colorItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         colorItem->setBackground(network->color());
         row.append(colorItem);
-        row.append(new QStandardItem(network->name()));
+
+        QStandardItem* nameItem = new QStandardItem(network->name());
+        nameItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        row.append(nameItem);
+
+        auto makeInfoItem = [](const QString& text) {
+            QStandardItem* item = new QStandardItem(text);
+            item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+            return item;
+        };
+
+        row.append(makeInfoItem(Network::formatEngineering(network->fmin())));
+        row.append(makeInfoItem(Network::formatEngineering(network->fmax())));
+
+        const QVector<double> freqs = network->frequencies();
+        const int freqCount = freqs.size();
+        row.append(makeInfoItem(QString::number(freqCount)));
+
         m_network_files_model->appendRow(row);
         m_networks.append(network);
     }
@@ -362,8 +388,11 @@ void MainWindow::setCascadeFrequencyRange(double fmin, double fmax)
 {
     if (fmax <= fmin)
         return;
-    m_cascade->setFmin(fmin);
-    m_cascade->setFmax(fmax);
+    int points = m_networkFrequencyPoints > 1 ? m_networkFrequencyPoints : m_cascade->pointCount();
+    if (points < 2)
+        points = 2;
+    updateNetworkFrequencySettings(fmin, fmax, points);
+    refreshNetworkFrequencyControls();
     updatePlots();
 }
 
@@ -371,7 +400,14 @@ void MainWindow::setCascadePointCount(int pointCount)
 {
     if (pointCount < 2)
         pointCount = 2;
-    m_cascade->setPointCount(pointCount);
+    double fmin = (m_networkFrequencyMin > 0.0) ? m_networkFrequencyMin : m_cascade->fmin();
+    double fmax = (m_networkFrequencyMax > 0.0) ? m_networkFrequencyMax : m_cascade->fmax();
+    if (fmax <= fmin) {
+        fmin = m_cascade->fmin();
+        fmax = m_cascade->fmax();
+    }
+    updateNetworkFrequencySettings(fmin, fmax, pointCount);
+    refreshNetworkFrequencyControls();
     updatePlots();
 }
 
@@ -813,6 +849,113 @@ void MainWindow::refreshGateControls()
     }
 }
 
+void MainWindow::refreshNetworkFrequencyControls()
+{
+    if (!ui)
+        return;
+
+    {
+        QSignalBlocker blocker(ui->lineEditFminNetworks);
+        ui->lineEditFminNetworks->setText(Network::formatEngineering(m_networkFrequencyMin));
+    }
+    {
+        QSignalBlocker blocker(ui->lineEditFmaxNetworks);
+        ui->lineEditFmaxNetworks->setText(Network::formatEngineering(m_networkFrequencyMax));
+    }
+    {
+        QSignalBlocker blocker(ui->lineEditNpointsNetworks);
+        ui->lineEditNpointsNetworks->setText(QString::number(std::max(m_networkFrequencyPoints, 2)));
+    }
+}
+
+void MainWindow::updateNetworkFrequencySettings(double fmin, double fmax, int pointCount)
+{
+    if (pointCount < 2)
+        pointCount = 2;
+
+    m_networkFrequencyMin = fmin;
+    m_networkFrequencyMax = fmax;
+    m_networkFrequencyPoints = pointCount;
+
+    if (m_cascade) {
+        m_cascade->setFmin(fmin);
+        m_cascade->setFmax(fmax);
+        m_cascade->setPointCount(pointCount);
+
+        const QList<Network*>& cascadeNetworks = m_cascade->getNetworks();
+        for (Network* network : cascadeNetworks) {
+            if (auto lumped = dynamic_cast<NetworkLumped*>(network)) {
+                lumped->setFmin(fmin);
+                lumped->setFmax(fmax);
+                lumped->setPointCount(pointCount);
+            }
+        }
+    }
+
+    for (Network* network : qAsConst(m_networks)) {
+        if (auto lumped = dynamic_cast<NetworkLumped*>(network)) {
+            lumped->setFmin(fmin);
+            lumped->setFmax(fmax);
+            lumped->setPointCount(pointCount);
+        }
+    }
+}
+
+bool MainWindow::applyNetworkFrequencySettingsFromUi()
+{
+    const double previousFmin = m_networkFrequencyMin;
+    const double previousFmax = m_networkFrequencyMax;
+    const int previousPoints = m_networkFrequencyPoints;
+
+    auto parseValue = [](QLineEdit *edit, double fallback) {
+        bool ok = false;
+        double value = edit->text().trimmed().toDouble(&ok);
+        return ok ? value : fallback;
+    };
+
+    double fmin = parseValue(ui->lineEditFminNetworks, previousFmin);
+    double fmax = parseValue(ui->lineEditFmaxNetworks, previousFmax);
+
+    bool pointsOk = false;
+    int points = ui->lineEditNpointsNetworks->text().trimmed().toInt(&pointsOk);
+    if (!pointsOk)
+        points = previousPoints;
+
+    if (!(fmin > 0.0))
+        fmin = previousFmin;
+    if (!(fmax > 0.0))
+        fmax = previousFmax;
+    if (points < 2)
+        points = previousPoints > 1 ? previousPoints : 2;
+
+    bool fminChanged = !nearlyEqual(fmin, previousFmin);
+    bool fmaxChanged = !nearlyEqual(fmax, previousFmax);
+
+    if (fmax <= fmin) {
+        if (fminChanged && !fmaxChanged) {
+            double step = std::max(std::abs(fmin) * 0.1, 1.0);
+            fmax = fmin + step;
+        } else if (fmaxChanged && !fminChanged) {
+            double step = std::max(std::abs(fmax) * 0.1, 1.0);
+            fmin = std::max(fmax - step, 0.0);
+            if (fmin <= 0.0)
+                fmin = previousFmin;
+        } else {
+            fmin = previousFmin;
+            fmax = previousFmax;
+        }
+    }
+
+    bool changed = !nearlyEqual(fmin, previousFmin)
+            || !nearlyEqual(fmax, previousFmax)
+            || points != previousPoints;
+
+    if (changed)
+        updateNetworkFrequencySettings(fmin, fmax, points);
+
+    return changed;
+}
+
 
 void MainWindow::on_actionOpen_triggered()
 {
@@ -1158,9 +1301,102 @@ void MainWindow::on_lineEditEpsilonR_editingFinished()
         updatePlots();
 }
 
+void MainWindow::on_lineEditFminNetworks_editingFinished()
+{
+    bool changed = applyNetworkFrequencySettingsFromUi();
+    refreshNetworkFrequencyControls();
+    if (changed)
+        updatePlots();
+}
+
+void MainWindow::on_lineEditFmaxNetworks_editingFinished()
+{
+    bool changed = applyNetworkFrequencySettingsFromUi();
+    refreshNetworkFrequencyControls();
+    if (changed)
+        updatePlots();
+}
+
+void MainWindow::on_lineEditNpointsNetworks_editingFinished()
+{
+    bool changed = applyNetworkFrequencySettingsFromUi();
+    refreshNetworkFrequencyControls();
+    if (changed)
+        updatePlots();
+}
+
 bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
     if (event->type() == QEvent::Wheel) {
+        if (obj == ui->lineEditFminNetworks || obj == ui->lineEditFmaxNetworks) {
+            QWheelEvent *wheelEvent = static_cast<QWheelEvent*>(event);
+            if (wheelEvent->angleDelta().y() == 0)
+                return true;
+
+            QLineEdit *edit = qobject_cast<QLineEdit*>(obj);
+            if (!edit)
+                return QMainWindow::eventFilter(obj, event);
+
+            const double fallback = (obj == ui->lineEditFminNetworks)
+                    ? m_networkFrequencyMin
+                    : m_networkFrequencyMax;
+
+            bool ok = false;
+            double value = edit->text().trimmed().toDouble(&ok);
+            if (!ok)
+                value = fallback;
+
+            const double magnitude = std::max(std::abs(value), 1.0);
+            const double step = magnitude * 0.1;
+            if (wheelEvent->angleDelta().y() > 0)
+                value += step;
+            else if (wheelEvent->angleDelta().y() < 0) {
+                value -= step;
+                if (value < 0.0)
+                    value = 0.0;
+            }
+
+            {
+                QSignalBlocker blocker(edit);
+                edit->setText(Network::formatEngineering(value));
+            }
+
+            bool changed = applyNetworkFrequencySettingsFromUi();
+            refreshNetworkFrequencyControls();
+            if (changed)
+                updatePlots();
+            return true;
+        }
+
+        if (obj == ui->lineEditNpointsNetworks) {
+            QWheelEvent *wheelEvent = static_cast<QWheelEvent*>(event);
+            if (wheelEvent->angleDelta().y() == 0)
+                return true;
+
+            int fallback = m_networkFrequencyPoints > 1 ? m_networkFrequencyPoints : 2;
+            bool ok = false;
+            int value = ui->lineEditNpointsNetworks->text().trimmed().toInt(&ok);
+            if (!ok)
+                value = fallback;
+
+            int step = std::max(value / 10, 1);
+            if (wheelEvent->angleDelta().y() > 0)
+                value += step;
+            else if (wheelEvent->angleDelta().y() < 0)
+                value = std::max(2, value - step);
+
+            {
+                QSignalBlocker blocker(ui->lineEditNpointsNetworks);
+                ui->lineEditNpointsNetworks->setText(QString::number(value));
+            }
+
+            bool changed = applyNetworkFrequencySettingsFromUi();
+            refreshNetworkFrequencyControls();
+            if (changed)
+                updatePlots();
+            return true;
+        }
+
         if (obj == ui->lineEditGateStart || obj == ui->lineEditGateStop) {
             QWheelEvent *wheelEvent = static_cast<QWheelEvent*>(event);
             if (wheelEvent->angleDelta().y() == 0)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -38,6 +38,7 @@ public:
     void addNetworkToCascade(Network* network);
     void setCascadeFrequencyRange(double fmin, double fmax);
     void setCascadePointCount(int pointCount);
+    void initializeFrequencyControls(bool freqSpecified, double fmin, double fmax, int pointCount, bool hasInitialFiles);
     NetworkCascade* cascade() const;
 
 private slots:
@@ -104,7 +105,7 @@ private:
     void refreshGateControls();
     bool applyNetworkFrequencySettingsFromUi();
     void refreshNetworkFrequencyControls();
-    void updateNetworkFrequencySettings(double fmin, double fmax, int pointCount);
+    void updateNetworkFrequencySettings(double fmin, double fmax, int pointCount, bool manualOverride = true);
     static bool nearlyEqual(double lhs, double rhs);
     void applyPhaseUnwrapSetting(bool unwrap);
 
@@ -134,5 +135,6 @@ private:
     double m_networkFrequencyMin;
     double m_networkFrequencyMax;
     int m_networkFrequencyPoints;
+    bool m_initialFrequencyConfigured;
 };
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -69,6 +69,9 @@ private slots:
     void on_lineEditGateStart_editingFinished();
     void on_lineEditGateStop_editingFinished();
     void on_lineEditEpsilonR_editingFinished();
+    void on_lineEditFminNetworks_editingFinished();
+    void on_lineEditFmaxNetworks_editingFinished();
+    void on_lineEditNpointsNetworks_editingFinished();
 
     void onNetworkFilesModelChanged(QStandardItem *item);
     void onNetworkLumpedModelChanged(QStandardItem *item);
@@ -99,6 +102,9 @@ private:
     void updateGraphSelectionFromTables();
     bool applyGateSettingsFromUi();
     void refreshGateControls();
+    bool applyNetworkFrequencySettingsFromUi();
+    void refreshNetworkFrequencyControls();
+    void updateNetworkFrequencySettings(double fmin, double fmax, int pointCount);
     static bool nearlyEqual(double lhs, double rhs);
     void applyPhaseUnwrapSetting(bool unwrap);
 
@@ -125,5 +131,8 @@ private:
     };
 
     SelectionOrigin m_lastSelectionOrigin;
+    double m_networkFrequencyMin;
+    double m_networkFrequencyMax;
+    int m_networkFrequencyPoints;
 };
 #endif // MAINWINDOW_H

--- a/networkcascade.cpp
+++ b/networkcascade.cpp
@@ -216,6 +216,7 @@ Network* NetworkCascade::clone(QObject* parent) const
     copy->setActive(m_is_active);
     copy->setFmin(m_fmin);
     copy->setFmax(m_fmax);
+    copy->setPointCount(m_pointCount);
     for (const auto& net : m_networks) {
         copy->addNetwork(net->clone(copy));
     }

--- a/networkcascade.h
+++ b/networkcascade.h
@@ -27,6 +27,9 @@ public:
     QVector<double> frequencies() const override;
     int portCount() const override;
 
+    void setFrequencyRange(double fmin, double fmax, bool manualOverride = true);
+    void clearManualFrequencyRange();
+    bool hasManualFrequencyRange() const;
     void setPointCount(int pointCount);
     int pointCount() const;
 
@@ -36,6 +39,7 @@ private:
 
     QList<Network*> m_networks;
     int m_pointCount;
+    bool m_manualFrequencyRange;
 };
 
 #endif // NETWORKCASCADE_H

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -29,7 +29,7 @@ NetworkLumped::NetworkLumped(NetworkType type, QObject *parent)
 }
 
 NetworkLumped::NetworkLumped(NetworkType type, const QVector<double>& values, QObject *parent)
-    : Network(parent), m_type(type)
+    : Network(parent), m_type(type), m_pointCount(1001)
 {
     initializeParameters(values);
     m_fmin = 1e6;
@@ -57,6 +57,7 @@ Network* NetworkLumped::clone(QObject* parent) const
     copy->setActive(m_is_active);
     copy->setFmin(m_fmin);
     copy->setFmax(m_fmax);
+    copy->setPointCount(m_pointCount);
     return copy;
 }
 
@@ -245,7 +246,8 @@ QPair<QVector<double>, QVector<double>> NetworkLumped::getPlotData(int s_param_i
         return {};
     }
 
-    Eigen::VectorXd freq = Eigen::VectorXd::LinSpaced(1001, m_fmin, m_fmax);
+    const int points = std::max(m_pointCount, 2);
+    Eigen::VectorXd freq = Eigen::VectorXd::LinSpaced(points, m_fmin, m_fmax);
     Eigen::MatrixXcd abcd_matrix = abcd(freq);
 
     Eigen::ArrayXcd sparam(freq.size());
@@ -320,8 +322,21 @@ QPair<QVector<double>, QVector<double>> NetworkLumped::getPlotData(int s_param_i
 
 QVector<double> NetworkLumped::frequencies() const
 {
-    Eigen::VectorXd freq = Eigen::VectorXd::LinSpaced(1001, m_fmin, m_fmax);
+    const int points = std::max(m_pointCount, 2);
+    Eigen::VectorXd freq = Eigen::VectorXd::LinSpaced(points, m_fmin, m_fmax);
     return QVector<double>(freq.data(), freq.data() + freq.size());
+}
+
+void NetworkLumped::setPointCount(int pointCount)
+{
+    if (pointCount < 2)
+        pointCount = 2;
+    m_pointCount = pointCount;
+}
+
+int NetworkLumped::pointCount() const
+{
+    return m_pointCount;
 }
 
 int NetworkLumped::portCount() const

--- a/networklumped.h
+++ b/networklumped.h
@@ -34,6 +34,9 @@ public:
     QVector<double> frequencies() const override;
     int portCount() const override;
 
+    void setPointCount(int pointCount);
+    int pointCount() const;
+
     int parameterCount() const;
     QString parameterDescription(int index) const;
     double parameterValue(int index) const;
@@ -51,6 +54,8 @@ private:
         double scale;
     };
     QVector<Parameter> m_parameters;
+
+    int m_pointCount;
 
     void initializeParameters(const QVector<double>& values);
     double parameterValueSI(int index) const;

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -1,5 +1,6 @@
 #include "networkcascade.h"
 #include "networkfile.h"
+#include "networklumped.h"
 #include <Eigen/Dense>
 #include <cassert>
 #include <complex>
@@ -65,10 +66,42 @@ void test_phase_unwrap_toggle()
     assert(differenceFound);
 }
 
+void test_lumped_frequency_point_count()
+{
+    NetworkLumped lumped(NetworkLumped::NetworkType::R_series, {50.0});
+    lumped.setFmin(2e6);
+    lumped.setFmax(12e6);
+    lumped.setPointCount(11);
+
+    const auto freqs = lumped.frequencies();
+    assert(freqs.size() == 11);
+    assert(std::abs(freqs.first() - 2e6) < 1e-6);
+    assert(std::abs(freqs.last() - 12e6) < 1e-6);
+
+    const auto plotData = lumped.getPlotData(0, PlotType::Magnitude);
+    assert(plotData.first.size() == 11);
+    assert(plotData.second.size() == 11);
+}
+
+void test_cascade_frequency_settings()
+{
+    NetworkCascade cascade;
+    cascade.setFmin(1e6);
+    cascade.setFmax(5e6);
+    cascade.setPointCount(9);
+
+    const auto freqs = cascade.frequencies();
+    assert(freqs.size() == 9);
+    assert(std::abs(freqs.first() - 1e6) < 1e-6);
+    assert(std::abs(freqs.last() - 5e6) < 1e-6);
+}
+
 int main()
 {
     test_cascade_two_files();
     test_phase_unwrap_toggle();
+    test_lumped_frequency_point_count();
+    test_cascade_frequency_settings();
     std::cout << "All NetworkCascade tests passed." << std::endl;
     return 0;
 }

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -86,9 +86,26 @@ void test_lumped_frequency_point_count()
 void test_cascade_frequency_settings()
 {
     NetworkCascade cascade;
-    cascade.setFmin(1e6);
-    cascade.setFmax(5e6);
+    cascade.setFrequencyRange(1e6, 5e6);
     cascade.setPointCount(9);
+
+    const auto freqs = cascade.frequencies();
+    assert(freqs.size() == 9);
+    assert(std::abs(freqs.first() - 1e6) < 1e-6);
+    assert(std::abs(freqs.last() - 5e6) < 1e-6);
+}
+
+void test_cascade_manual_range_persistence()
+{
+    NetworkFile net(QStringLiteral("test/a (1).s2p"));
+    NetworkFile net2(QStringLiteral("test/a (2).s2p"));
+
+    NetworkCascade cascade;
+    cascade.setFrequencyRange(1e6, 5e6);
+    cascade.setPointCount(9);
+
+    cascade.addNetwork(&net);
+    cascade.addNetwork(&net2);
 
     const auto freqs = cascade.frequencies();
     assert(freqs.size() == 9);
@@ -102,6 +119,7 @@ int main()
     test_phase_unwrap_toggle();
     test_lumped_frequency_point_count();
     test_cascade_frequency_settings();
+    test_cascade_manual_range_persistence();
     std::cout << "All NetworkCascade tests passed." << std::endl;
     return 0;
 }

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -136,6 +136,7 @@ void test_cascade_manual_range_persistence()
     assert(freqs.size() == 9);
     assert(std::abs(freqs.first() - 1e6) < 1e-6);
     assert(std::abs(freqs.last() - 5e6) < 1e-6);
+}
 
 void test_lumped_phase_unwrap_matches_manual()
 {


### PR DESCRIPTION
## Summary
- add editable frequency controls for lumped networks and cascade plots, including wheel support and engineering formatting
- propagate frequency range and point count changes to network models and update plots immediately
- display fmin, fmax, and point count metadata for imported network files and extend coverage for the new frequency logic

## Testing
- `./test.sh` *(fails: missing Qt6 pkg-config metadata in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a358b38c8326a11e61d14f9710f7