### PR TITLE
Add crosshair toggle for cartesian cursors

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -66,6 +66,7 @@ MainWindow::MainWindow(QWidget *parent)
     , m_initialFrequencyConfigured(false)
 {
     ui->setupUi(this);
+    ui->checkBoxCrossHair->setChecked(true);
     m_plot_manager = new PlotManager(ui->widgetGraph, this);
 
     ui->lineEditGateStart->installEventFilter(this);
@@ -122,6 +123,10 @@ MainWindow::MainWindow(QWidget *parent)
 
     connect(ui->checkBoxCursorB, &QCheckBox::stateChanged, this, [this](int state){
         m_plot_manager->setCursorBVisible(state == Qt::Checked);
+    });
+
+    connect(ui->checkBoxCrossHair, &QCheckBox::stateChanged, this, [this](int state){
+        m_plot_manager->setCrosshairEnabled(state == Qt::Checked);
     });
 
     ui->checkBoxS21->setChecked(true);

--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -49,6 +49,7 @@ PlotManager::PlotManager(QCustomPlot* plot, QObject *parent)
     , m_color_index(0)
     , m_keepAspectConnected(false)
     , m_currentPlotType(PlotType::Magnitude)
+    , m_crosshairEnabled(true)
 {
     m_plot->setInteractions(QCP::iRangeDrag | QCP::iRangeZoom | QCP::iSelectPlottables | QCP::iMultiSelect);
     connect(m_plot, &QCustomPlot::mouseDoubleClick, this, &PlotManager::mouseDoubleClick);
@@ -174,8 +175,7 @@ QCPAbstractPlottable* PlotManager::plot(const QVector<double> &x, const QVector<
 
 void PlotManager::configureCursorStyles(PlotType type)
 {
-    if (type == PlotType::Smith)
-    {
+    auto configureSmithMarkers = [this]() {
         mTracerA->setStyle(QCPItemTracer::tsTriangle);
         mTracerA->setPen(QPen(Qt::red, 0));
         mTracerA->setBrush(Qt::red);
@@ -185,8 +185,13 @@ void PlotManager::configureCursorStyles(PlotType type)
         mTracerB->setPen(QPen(Qt::blue, 0));
         mTracerB->setBrush(Qt::blue);
         mTracerTextB->setColor(Qt::blue);
+    };
+
+    if (type == PlotType::Smith)
+    {
+        configureSmithMarkers();
     }
-    else
+    else if (m_crosshairEnabled)
     {
         mTracerA->setStyle(QCPItemTracer::tsCrosshair);
         mTracerA->setPen(QPen(Qt::black, 0));
@@ -198,6 +203,20 @@ void PlotManager::configureCursorStyles(PlotType type)
         mTracerB->setBrush(Qt::NoBrush);
         mTracerTextB->setColor(Qt::blue);
     }
+    else
+    {
+        configureSmithMarkers();
+    }
+}
+
+void PlotManager::setCrosshairEnabled(bool enabled)
+{
+    if (m_crosshairEnabled == enabled)
+        return;
+
+    m_crosshairEnabled = enabled;
+    configureCursorStyles(m_currentPlotType);
+    m_plot->replot();
 }
 
 QCPGraph *PlotManager::firstGraph() const

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -34,6 +34,7 @@ public:
     void autoscale();
     QColor nextColor();
     void setXAxisScaleType(QCPAxis::ScaleType type);
+    void setCrosshairEnabled(bool enabled);
 
 public slots:
     void mouseDoubleClick(QMouseEvent *event);
@@ -86,6 +87,7 @@ private:
     QMap<QCPItemTracer*, int> m_tracerIndices;
     bool m_keepAspectConnected;
     PlotType m_currentPlotType;
+    bool m_crosshairEnabled;
 };
 
 #endif // PLOTMANAGER_H


### PR DESCRIPTION
## Summary
- add a PlotManager switch to control cartesian cursor crosshair styles
- connect the MainWindow checkbox to toggle between crosshair and marker cursors

## Testing
- ./test.sh *(fails: missing Qt6 pkg-config files in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b6a184c0832696af4fd8d6aafc0f