### PR TITLE
Refactor network cascade to use S-parameters

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -101,15 +101,12 @@ bool saveCascadeToFile(const NetworkCascade& cascade, const Eigen::VectorXd& fre
     const Eigen::Index rows = freq.size();
     const Eigen::Index cols = static_cast<Eigen::Index>(data.ports * data.ports);
     data.sparams.resize(rows, cols);
+    data.sparams.setZero();
 
-    Eigen::MatrixXcd abcd = cascade.abcd(freq);
+    Eigen::MatrixXcd s_matrix = cascade.sparameters(freq);
     for (Eigen::Index row = 0; row < rows; ++row) {
-        Eigen::Matrix2cd abcdPoint;
-        abcdPoint << abcd(row, 0), abcd(row, 1),
-                     abcd(row, 2), abcd(row, 3);
-        Eigen::Vector4cd s = Network::abcd2s(abcdPoint);
-        for (Eigen::Index col = 0; col < cols; ++col) {
-            data.sparams(row, col) = s(col);
+        for (Eigen::Index col = 0; col < cols && col < s_matrix.cols(); ++col) {
+            data.sparams(row, col) = s_matrix(row, col);
         }
     }
 

--- a/network.h
+++ b/network.h
@@ -24,7 +24,7 @@ public:
 
     virtual QString name() const = 0;
     virtual QString displayName() const;
-    virtual Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const = 0;
+    virtual Eigen::MatrixXcd sparameters(const Eigen::VectorXd& freq) const = 0;
     virtual QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) = 0;
     virtual Network* clone(QObject* parent = nullptr) const = 0;
     virtual QVector<double> frequencies() const = 0;

--- a/networkcascade.h
+++ b/networkcascade.h
@@ -20,7 +20,7 @@ public:
     const QList<Network*>& getNetworks() const;
 
     QString name() const override;
-    Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const override;
+    Eigen::MatrixXcd sparameters(const Eigen::VectorXd& freq) const override;
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override;
     Network* clone(QObject* parent = nullptr) const override;
 

--- a/networkfile.cpp
+++ b/networkfile.cpp
@@ -202,21 +202,25 @@ int NetworkFile::portCount() const
     return m_data->ports;
 }
 
-Eigen::MatrixXcd NetworkFile::abcd(const Eigen::VectorXd& freq) const
+Eigen::MatrixXcd NetworkFile::sparameters(const Eigen::VectorXd& freq) const
 {
-    if (!m_data) {
+    if (!m_data || freq.size() == 0) {
         return {};
     }
 
-    Eigen::MatrixXcd abcd_matrix(freq.size(), 4);
+    const int ports = m_data->ports;
+    if (ports != 2) {
+        return {};
+    }
+
+    Eigen::MatrixXcd s_matrix(freq.size(), 4);
     for (int i = 0; i < freq.size(); ++i) {
         std::complex<double> s11 = interpolate_s_param(freq(i), 0);
         std::complex<double> s12 = interpolate_s_param(freq(i), 1);
         std::complex<double> s21 = interpolate_s_param(freq(i), 2);
         std::complex<double> s22 = interpolate_s_param(freq(i), 3);
-        Eigen::Matrix2cd abcd_point = s2abcd(s11, s12, s21, s22);
-        abcd_matrix.row(i) << abcd_point(0, 0), abcd_point(0, 1), abcd_point(1, 0), abcd_point(1, 1);
+        s_matrix.row(i) << s11, s12, s21, s22;
     }
 
-    return abcd_matrix;
+    return s_matrix;
 }

--- a/networkfile.h
+++ b/networkfile.h
@@ -12,7 +12,7 @@ public:
     explicit NetworkFile(const QString &filePath, QObject *parent = nullptr);
 
     QString name() const override;
-    Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const override;
+    Eigen::MatrixXcd sparameters(const Eigen::VectorXd& freq) const override;
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override;
     Network* clone(QObject* parent = nullptr) const override;
 

--- a/networklumped.h
+++ b/networklumped.h
@@ -28,7 +28,7 @@ public:
 
     QString name() const override;
     QString displayName() const override;
-    Eigen::MatrixXcd abcd(const Eigen::VectorXd& freq) const override;
+    Eigen::MatrixXcd sparameters(const Eigen::VectorXd& freq) const override;
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override;
     Network* clone(QObject* parent = nullptr) const override;
     QVector<double> frequencies() const override;

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -19,12 +19,7 @@ void test_cascade_two_files()
     Eigen::VectorXd freq(1);
     freq << 40e6; // 40 MHz
 
-    Eigen::MatrixXcd abcd_matrix = cascade.abcd(freq);
-    Eigen::Matrix2cd abcd;
-    abcd << abcd_matrix(0, 0), abcd_matrix(0, 1),
-             abcd_matrix(0, 2), abcd_matrix(0, 3);
-
-    Eigen::Vector4cd s = Network::abcd2s(abcd);
+    Eigen::MatrixXcd s_matrix = cascade.sparameters(freq);
 
     std::complex<double> s11_expected(0.014920405958677847, 0.01630490315700499);
     std::complex<double> s12_expected(0.9574040676271609, -0.20781677254865813);
@@ -36,10 +31,10 @@ void test_cascade_two_files()
                std::abs(a.imag() - b.imag()) < 1e-6;
     };
 
-    assert(close(s[0], s11_expected));
-    assert(close(s[1], s12_expected));
-    assert(close(s[2], s21_expected));
-    assert(close(s[3], s22_expected));
+    assert(close(s_matrix(0, 0), s11_expected));
+    assert(close(s_matrix(0, 1), s12_expected));
+    assert(close(s_matrix(0, 2), s21_expected));
+    assert(close(s_matrix(0, 3), s22_expected));
 }
 
 namespace {


### PR DESCRIPTION
## Summary
- update the base network interface to expose s-parameters and cascade them via the Redheffer star product for improved stability
- convert lumped and file-backed network implementations to generate s-parameters (with an ABCD-to-S helper for lumped elements)
- adjust cascade export logic and unit tests to operate directly on s-parameters

## Testing
- ./test.sh *(fails: Qt6 pkg-config files are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70cfc46588326a793a7d25214cb2c