### PR TITLE
Refactor tables to QTableWidget

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -23,7 +23,7 @@ QT_END_NAMESPACE
 class Server;
 class NetworkFile;
 class PlotManager;
-class QTableView;
+class QTableWidget;
 class QCPAbstractPlottable;
 
 class MainWindow : public QMainWindow
@@ -94,7 +94,7 @@ private:
     void updatePlots();
     void setupModels();
     void setupViews();
-    void setupTableColumns(QTableView* view);
+    void setupTableColumns(QTableWidget* view);
     void populateLumpedNetworkTable();
     void configureLumpedAndCascadeColumns(int parameterCount);
     void appendParameterItems(QList<QStandardItem*>& row, Network* network);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -80,7 +80,7 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QTableView" name="tableViewNetworkFiles">
+          <widget class="QTableWidget" name="tableWidgetNetworkFiles">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -93,6 +93,42 @@
               <pointsize>8</pointsize>
              </font>
             </property>
+            <property name="columnCount">
+             <number>6</number>
+            </property>
+            <property name="rowCount">
+             <number>0</number>
+            </property>
+            <column>
+             <property name="text">
+              <string>  </string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>  </string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>File</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>fmin</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>fmax</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>pts</string>
+             </property>
+            </column>
             <attribute name="verticalHeaderMinimumSectionSize">
              <number>18</number>
             </attribute>
@@ -155,13 +191,34 @@
            </layout>
           </item>
           <item>
-           <widget class="QTableView" name="tableViewNetworkLumped">
+          <widget class="QTableWidget" name="tableWidgetNetworkLumped">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="columnCount">
+             <number>3</number>
+            </property>
+            <property name="rowCount">
+             <number>0</number>
+            </property>
+            <column>
+             <property name="text">
+              <string>  </string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>  </string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Name</string>
+             </property>
+            </column>
             <attribute name="verticalHeaderMinimumSectionSize">
              <number>18</number>
             </attribute>
@@ -171,13 +228,34 @@
            </widget>
           </item>
           <item>
-           <widget class="QTableView" name="tableViewCascade">
+           <widget class="QTableWidget" name="tableWidgetCascade">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="columnCount">
+             <number>3</number>
+            </property>
+            <property name="rowCount">
+             <number>0</number>
+            </property>
+            <column>
+             <property name="text">
+              <string>  </string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>  </string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Name</string>
+             </property>
+            </column>
             <attribute name="verticalHeaderMinimumSectionSize">
              <number>18</number>
             </attribute>


### PR DESCRIPTION
## Summary
- replace the main window table views with QTableWidget instances
- move static column definitions for the tables into the .ui file and load the headers from the designer configuration
- update table-related helpers and event hooks to work with the new widget type

## Testing
- ./build.sh *(fails: Qt6 pkg-config files are unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d98c369fcc8326b7a1f4264c241236