### PR TITLE
Improve build script Qt dependency handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,100 @@
 set -euo pipefail
 set -x
 
-MOC=/usr/lib/qt6/libexec/moc
+# Locate the Qt meta-object compiler. Different distributions install it
+# under different names/locations (e.g. moc, moc-qt6). If it is missing we
+# attempt to install the required Qt development packages automatically on
+# Debian based systems so that the script works out-of-the-box in CI images
+# that start without Qt preinstalled.
+MOC=""
+
+find_moc() {
+    if command -v qtpaths6 >/dev/null 2>&1; then
+        local qt_libexec
+        qt_libexec="$(qtpaths6 --query QT_INSTALL_LIBEXECS || true)"
+        if [ -n "$qt_libexec" ] && [ -x "$qt_libexec/moc" ]; then
+            MOC="$qt_libexec/moc"
+            return 0
+        fi
+        local qt_bins
+        qt_bins="$(qtpaths6 --query QT_INSTALL_BINS || true)"
+        if [ -n "$qt_bins" ] && [ -x "$qt_bins/moc" ]; then
+            MOC="$qt_bins/moc"
+            return 0
+        fi
+    fi
+
+    if command -v moc-qt6 >/dev/null 2>&1; then
+        MOC="$(command -v moc-qt6)"
+    elif command -v moc >/dev/null 2>&1; then
+        MOC="$(command -v moc)"
+    fi
+
+    if [ -z "$MOC" ]; then
+        return 1
+    fi
+
+    return 0
+}
+
+install_qt_dependencies() {
+    if [ "${FSNPVIEW_NO_AUTO_SETUP:-}" = "1" ]; then
+        return 1
+    fi
+
+    if ! command -v apt-get >/dev/null 2>&1; then
+        return 1
+    fi
+
+    echo "info: Qt development tools not found, installing dependencies via apt-get." >&2
+
+    # Prefer sudo when available (e.g. for non-root users) but fall back to
+    # running the commands directly when already running as root.
+    if command -v sudo >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y build-essential qt6-base-dev qt6-base-dev-tools libeigen3-dev
+    else
+        apt-get update
+        apt-get install -y build-essential qt6-base-dev qt6-base-dev-tools libeigen3-dev
+    fi
+
+    return 0
+}
+
+if ! find_moc; then
+    if install_qt_dependencies && find_moc; then
+        :
+    else
+        echo "error: Qt 'moc' executable not found. Install qt6-base-dev or run ./setup.sh." >&2
+        exit 1
+    fi
+fi
+
+# Ensure pkg-config can locate the Qt6 .pc files. Debian based systems install
+# them in a qt6 specific subdirectory that is not part of the default search
+# path.
+qt_pkgconfig_dirs=(
+    /usr/lib/x86_64-linux-gnu/qt6/pkgconfig
+    /usr/lib/qt6/pkgconfig
+    /usr/local/lib/qt6/pkgconfig
+    /usr/lib64/qt6/pkgconfig
+)
+
+for dir in "${qt_pkgconfig_dirs[@]}"; do
+    if [ -d "$dir" ]; then
+        if [ -z "${PKG_CONFIG_PATH:-}" ]; then
+            export PKG_CONFIG_PATH="$dir"
+        elif [[ ":$PKG_CONFIG_PATH:" != *":$dir:"* ]]; then
+            export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$dir"
+        fi
+    fi
+done
+
+if ! pkg-config --exists Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport; then
+    echo "error: Qt6 pkg-config files were not found. Install qt6-base-dev or set PKG_CONFIG_PATH." >&2
+    exit 1
+fi
+
 MOC_INCLUDES="$(pkg-config --cflags Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)"
 
 g++ -std=c++17 -I/usr/include/eigen3 -I. tests/parser_touchstone_tests.cpp parser_touchstone.cpp -o parser_touchstone_tests


### PR DESCRIPTION
## Summary
- detect the Qt meta-object compiler via qtpaths6 libexec/bin lookups or common moc aliases
- automatically install required Qt6 development packages via apt-get when moc is missing (with an opt-out env flag)
- configure PKG_CONFIG_PATH with common Qt6 pkg-config locations before building
- provide clearer error messages when required Qt tools are missing

## Testing
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d98e767f888326a83d4c9544e3fccb