### PR TITLE
Adjust network table sizing behavior

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -14,6 +14,7 @@
 #include <QTableView>
 
 #include <QItemSelectionModel>
+#include <QAbstractItemModel>
 #include <QSignalBlocker>
 #include <QColorDialog>
 #include <QVariant>
@@ -25,6 +26,10 @@
 #include <QApplication>
 #include <QStringList>
 #include <QLineEdit>
+#include <QList>
+#include <QSizePolicy>
+#include <QScrollBar>
+#include <QTimer>
 
 #include <algorithm>
 #include <cmath>
@@ -66,6 +71,10 @@ MainWindow::MainWindow(QWidget *parent)
     , m_initialFrequencyConfigured(false)
 {
     ui->setupUi(this);
+    ui->splitter_3->setStretchFactor(0, 0);
+    ui->splitter_3->setStretchFactor(1, 1);
+    ui->splitter_2->setStretchFactor(0, 0);
+    ui->splitter_2->setStretchFactor(1, 1);
     ui->checkBoxCrossHair->setChecked(true);
     m_plot_manager = new PlotManager(ui->widgetGraph, this);
 
@@ -91,6 +100,20 @@ MainWindow::MainWindow(QWidget *parent)
 
     setupModels();
     setupViews();
+
+    auto connectGeometryUpdates = [this](QAbstractItemModel *model) {
+        if (!model)
+            return;
+        connect(model, &QAbstractItemModel::modelReset, this, &MainWindow::updateNetworkTablesGeometry);
+        connect(model, &QAbstractItemModel::layoutChanged, this, &MainWindow::updateNetworkTablesGeometry);
+        connect(model, &QAbstractItemModel::rowsInserted, this, &MainWindow::updateNetworkTablesGeometry);
+        connect(model, &QAbstractItemModel::rowsRemoved, this, &MainWindow::updateNetworkTablesGeometry);
+        connect(model, &QAbstractItemModel::dataChanged, this, &MainWindow::updateNetworkTablesGeometry);
+    };
+
+    connectGeometryUpdates(m_network_files_model);
+    connectGeometryUpdates(m_network_lumped_model);
+
     populateLumpedNetworkTable();
     applyPhaseUnwrapSetting(ui->checkBoxPhaseUnwrap->isChecked());
     updateNetworkFrequencySettings(m_cascade->fmin(), m_cascade->fmax(), m_cascade->pointCount(), false);
@@ -132,6 +155,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->checkBoxS21->setChecked(true);
     updatePlots();
     m_plot_manager->autoscale();
+    QTimer::singleShot(0, this, &MainWindow::updateNetworkTablesGeometry);
 }
 
 MainWindow::~MainWindow()
@@ -163,6 +187,7 @@ void MainWindow::setupViews()
     ui->tableViewNetworkFiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->tableViewNetworkFiles->setSelectionBehavior(QAbstractItemView::SelectRows);
     ui->tableViewNetworkFiles->setItemDelegate(new SelectionBoldDelegate(ui->tableViewNetworkFiles));
+    ui->tableViewNetworkFiles->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
     setupTableColumns(ui->tableViewNetworkFiles);
 
     ui->tableViewNetworkLumped->setModel(m_network_lumped_model);
@@ -170,6 +195,7 @@ void MainWindow::setupViews()
     ui->tableViewNetworkLumped->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->tableViewNetworkLumped->setSelectionBehavior(QAbstractItemView::SelectRows);
     ui->tableViewNetworkLumped->setItemDelegate(new SelectionBoldDelegate(ui->tableViewNetworkLumped));
+    ui->tableViewNetworkLumped->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
     setupTableColumns(ui->tableViewNetworkLumped);
 
 
@@ -197,6 +223,72 @@ void MainWindow::setupTableColumns(QTableView* view)
     }
 }
 
+void MainWindow::resizeEvent(QResizeEvent *event)
+{
+    QMainWindow::resizeEvent(event);
+    updateNetworkTablesGeometry();
+}
+
+void MainWindow::updateNetworkTablesGeometry()
+{
+    int filesHeight = adjustTableViewToContents(ui->tableViewNetworkFiles);
+    int lumpedHeight = adjustTableViewToContents(ui->tableViewNetworkLumped);
+
+    if (filesHeight > 0) {
+        ui->splitter_3->setSizes(QList<int>{filesHeight, 1});
+    }
+
+    if (lumpedHeight > 0) {
+        ui->splitter_2->setSizes(QList<int>{lumpedHeight, 1});
+    }
+}
+
+int MainWindow::adjustTableViewToContents(QTableView *view)
+{
+    if (!view || !view->model())
+        return 0;
+
+    view->setMaximumHeight(QWIDGETSIZE_MAX);
+    view->resizeRowsToContents();
+
+    QHeaderView *header = view->horizontalHeader();
+    int headerHeight = header && header->isVisible() ? header->height() : 0;
+    if (header && headerHeight == 0) {
+        headerHeight = header->sizeHint().height();
+    }
+
+    int height = headerHeight;
+    const int rows = view->model()->rowCount();
+    for (int row = 0; row < rows; ++row) {
+        height += view->rowHeight(row);
+    }
+
+    height += 2 * view->frameWidth();
+
+    if (QScrollBar *scrollBar = view->horizontalScrollBar()) {
+        if (scrollBar->isVisible()) {
+            height += scrollBar->height();
+        }
+    }
+
+    if (height <= 0) {
+        height = view->sizeHint().height();
+    }
+
+    if (height <= 0) {
+        height = headerHeight;
+    }
+
+    if (height <= 0) {
+        height = 1;
+    }
+
+    view->setMaximumHeight(height);
+    view->setMinimumHeight(0);
+    view->updateGeometry();
+    return height;
+}
+
 void MainWindow::configureLumpedAndCascadeColumns(int parameterCount)
 {
     m_lumpedParameterCount = parameterCount;
@@ -212,6 +304,8 @@ void MainWindow::configureLumpedAndCascadeColumns(int parameterCount)
 
     m_network_cascade_model->setColumnCount(headers.size());
     m_network_cascade_model->setHorizontalHeaderLabels(headers);
+
+    updateNetworkTablesGeometry();
 }
 
 void MainWindow::appendParameterItems(QList<QStandardItem*>& row, Network* network)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -25,6 +25,7 @@ class NetworkFile;
 class PlotManager;
 class QTableView;
 class QCPAbstractPlottable;
+class QResizeEvent;
 
 class MainWindow : public QMainWindow
 {
@@ -89,12 +90,15 @@ private slots:
 protected:
     void keyPressEvent(QKeyEvent* event) override;
     bool eventFilter(QObject* obj, QEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
     void updatePlots();
     void setupModels();
     void setupViews();
     void setupTableColumns(QTableView* view);
+    void updateNetworkTablesGeometry();
+    int adjustTableViewToContents(QTableView* view);
     void populateLumpedNetworkTable();
     void configureLumpedAndCascadeColumns(int parameterCount);
     void appendParameterItems(QList<QStandardItem*>& row, Network* network);


### PR DESCRIPTION
## Summary
- limit the network file and lumped tables to the height of their contents and let the cascade table consume remaining space
- update the splitters and table size policies whenever the models or window size changes to keep the layout consistent

## Testing
- not run (Qt build/test environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9995f910883268f6a67f32116864e