### PR TITLE
Allow marker curve dragging without crosshairs

### DIFF
--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -953,7 +953,12 @@ void PlotManager::checkForTracerDrag(QMouseEvent *event, QCPItemTracer *tracer)
             }
         }
     } else {
-        if (qAbs(event->pos().x() - tracerPos.x()) < 5) {
+        if (!m_crosshairEnabled) {
+            if (QLineF(event->pos(), tracerPos).length() < 8) {
+                mDraggedTracer = tracer;
+                mDragMode = DragMode::Horizontal;
+            }
+        } else if (qAbs(event->pos().x() - tracerPos.x()) < 5) {
             mDraggedTracer = tracer;
             mDragMode = DragMode::Vertical;
         } else if (qAbs(event->pos().y() - tracerPos.y()) < 5) {


### PR DESCRIPTION
## Summary
- treat marker drags like horizontal crosshairs when crosshairs are disabled
- allow dragging markers onto other curves in cartesian plots even without crosshair visuals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99c06a22883268ffc0937323cb2ec