### PR TITLE
Add cascade status bar icons

### DIFF
--- a/fsnpview.pro
+++ b/fsnpview.pro
@@ -60,6 +60,9 @@ HEADERS += \
 FORMS += \
     mainwindow.ui
 
+RESOURCES += \
+    icons.qrc
+
 
 win32 {
     #INCLUDEPATH += C:\home\projekte\Qt\eigen-3.4.0

--- a/icons.qrc
+++ b/icons.qrc
@@ -1,0 +1,18 @@
+<RCC>
+    <qresource prefix="/icons">
+        <file>icons/C_series.png</file>
+        <file>icons/C_shunt.png</file>
+        <file>icons/L_series.png</file>
+        <file>icons/L_shunt.png</file>
+        <file>icons/RLC_par_ser.png</file>
+        <file>icons/RLC_par_shunt.png</file>
+        <file>icons/RLC_ser_shunt.png</file>
+        <file>icons/R_series.png</file>
+        <file>icons/R_shunt.png</file>
+        <file>icons/TL.png</file>
+        <file>icons/TL_lossy.png</file>
+        <file>icons/fileNetwork.png</file>
+        <file>icons/p1.png</file>
+        <file>icons/p2.png</file>
+    </qresource>
+</RCC>

--- a/icons.qrc
+++ b/icons.qrc
@@ -1,18 +1,18 @@
 <RCC>
     <qresource prefix="/icons">
-        <file>icons/C_series.png</file>
-        <file>icons/C_shunt.png</file>
-        <file>icons/L_series.png</file>
-        <file>icons/L_shunt.png</file>
-        <file>icons/RLC_par_ser.png</file>
-        <file>icons/RLC_par_shunt.png</file>
-        <file>icons/RLC_ser_shunt.png</file>
-        <file>icons/R_series.png</file>
-        <file>icons/R_shunt.png</file>
-        <file>icons/TL.png</file>
-        <file>icons/TL_lossy.png</file>
-        <file>icons/fileNetwork.png</file>
-        <file>icons/p1.png</file>
-        <file>icons/p2.png</file>
+        <file alias="C_series.png">icons/C_series.png</file>
+        <file alias="C_shunt.png">icons/C_shunt.png</file>
+        <file alias="L_series.png">icons/L_series.png</file>
+        <file alias="L_shunt.png">icons/L_shunt.png</file>
+        <file alias="RLC_par_ser.png">icons/RLC_par_ser.png</file>
+        <file alias="RLC_par_shunt.png">icons/RLC_par_shunt.png</file>
+        <file alias="RLC_ser_shunt.png">icons/RLC_ser_shunt.png</file>
+        <file alias="R_series.png">icons/R_series.png</file>
+        <file alias="R_shunt.png">icons/R_shunt.png</file>
+        <file alias="TL.png">icons/TL.png</file>
+        <file alias="TL_lossy.png">icons/TL_lossy.png</file>
+        <file alias="fileNetwork.png">icons/fileNetwork.png</file>
+        <file alias="p1.png">icons/p1.png</file>
+        <file alias="p2.png">icons/p2.png</file>
     </qresource>
 </RCC>

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -26,6 +26,7 @@ class PlotManager;
 class QTableView;
 class QCPAbstractPlottable;
 class QResizeEvent;
+class QLabel;
 
 class MainWindow : public QMainWindow
 {
@@ -112,6 +113,8 @@ private:
     void updateNetworkFrequencySettings(double fmin, double fmax, int pointCount, bool manualOverride = true);
     static bool nearlyEqual(double lhs, double rhs);
     void applyPhaseUnwrapSetting(bool unwrap);
+    void updateCascadeStatusIcons();
+    QString iconResourceForNetwork(const Network* network) const;
 
 
     Ui::MainWindow *ui;
@@ -140,5 +143,7 @@ private:
     double m_networkFrequencyMax;
     int m_networkFrequencyPoints;
     bool m_initialFrequencyConfigured;
+
+    QVector<QLabel*> m_cascadeStatusIconLabels;
 };
 #endif // MAINWINDOW_H

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -51,6 +51,11 @@ NetworkLumped::NetworkLumped(NetworkType type, std::initializer_list<double> val
 {
 }
 
+NetworkLumped::NetworkType NetworkLumped::type() const
+{
+    return m_type;
+}
+
 Network* NetworkLumped::clone(QObject* parent) const
 {
     QVector<double> values;

--- a/networklumped.h
+++ b/networklumped.h
@@ -26,6 +26,8 @@ public:
     NetworkLumped(NetworkType type, const QVector<double>& values, QObject *parent = nullptr);
     NetworkLumped(NetworkType type, std::initializer_list<double> values, QObject *parent = nullptr);
 
+    NetworkType type() const;
+
     QString name() const override;
     QString displayName() const override;
     Eigen::MatrixXcd sparameters(const Eigen::VectorXd& freq) const override;


### PR DESCRIPTION
## Summary
- load the PNG icon set into the application via a new Qt resource collection
- show icons for active cascade networks together with port boundary markers in the status bar
- expose lumped-network type metadata so the UI can resolve the proper icon for each cascade element

## Testing
- not run (GUI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9ae9b900083268b4cd24f57665710