### PR TITLE
Show cascade icons without status bar gaps

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -35,6 +35,10 @@
 #include <QStatusBar>
 #include <QLabel>
 #include <QPixmap>
+#include <QSizeF>
+#include <QHBoxLayout>
+#include <QLayout>
+#include <QWidget>
 
 #include <algorithm>
 #include <cmath>
@@ -75,9 +79,27 @@ MainWindow::MainWindow(QWidget *parent)
     , m_networkFrequencyMax(0.0)
     , m_networkFrequencyPoints(0)
     , m_initialFrequencyConfigured(false)
+    , m_cascadeStatusIconContainer(nullptr)
+    , m_cascadeStatusIconLayout(nullptr)
 {
     ui->setupUi(this);
     ui->statusbar->setEnabled(true);
+    ui->statusbar->setContentsMargins(0, 0, 0, 0);
+    ui->statusbar->setStyleSheet(QStringLiteral("QStatusBar::item { border: none; margin: 0px; padding: 0px; }"));
+    if (QLayout* statusLayout = ui->statusbar->layout()) {
+        statusLayout->setContentsMargins(0, 0, 0, 0);
+        statusLayout->setSpacing(0);
+    }
+
+    m_cascadeStatusIconContainer = new QWidget(ui->statusbar);
+    m_cascadeStatusIconContainer->setContentsMargins(0, 0, 0, 0);
+    m_cascadeStatusIconContainer->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_cascadeStatusIconContainer->setStyleSheet(QStringLiteral("border: none; margin: 0px; padding: 0px;"));
+    m_cascadeStatusIconLayout = new QHBoxLayout(m_cascadeStatusIconContainer);
+    m_cascadeStatusIconLayout->setContentsMargins(0, 0, 0, 0);
+    m_cascadeStatusIconLayout->setSpacing(0);
+    ui->statusbar->addWidget(m_cascadeStatusIconContainer, 0);
+
     ui->splitter_3->setStretchFactor(0, 0);
     ui->splitter_3->setStretchFactor(1, 1);
     ui->splitter_2->setStretchFactor(0, 0);
@@ -728,13 +750,17 @@ void MainWindow::updateCascadeStatusIcons()
     if (!ui || !ui->statusbar)
         return;
 
-    for (QLabel* label : qAsConst(m_cascadeStatusIconLabels)) {
-        if (!label)
-            continue;
-        ui->statusbar->removeWidget(label);
-        delete label;
+    if (!m_cascadeStatusIconContainer || !m_cascadeStatusIconLayout)
+        return;
+
+    while (QLayoutItem* item = m_cascadeStatusIconLayout->takeAt(0)) {
+        if (QWidget* widget = item->widget()) {
+            delete widget;
+        }
+        delete item;
     }
-    m_cascadeStatusIconLabels.clear();
+
+    m_cascadeStatusIconContainer->setVisible(false);
 
     if (!m_cascade)
         return;
@@ -759,13 +785,21 @@ void MainWindow::updateCascadeStatusIcons()
         QPixmap pixmap(QStringLiteral(":/icons/%1.png").arg(key));
         if (pixmap.isNull())
             continue;
-        QLabel* label = new QLabel(ui->statusbar);
+        QLabel* label = new QLabel(m_cascadeStatusIconContainer);
+        label->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+        const qreal deviceRatio = pixmap.devicePixelRatio();
+        const QSize logicalSize = QSizeF(pixmap.width() / deviceRatio, pixmap.height() / deviceRatio).toSize();
+        label->setFixedSize(logicalSize);
+        label->setScaledContents(false);
+        label->setAlignment(Qt::AlignCenter);
         label->setPixmap(pixmap);
         label->setContentsMargins(0, 0, 0, 0);
         label->setMargin(0);
-        ui->statusbar->addWidget(label);
-        m_cascadeStatusIconLabels.append(label);
+        label->setStyleSheet(QStringLiteral("border: none; margin: 0px; padding: 0px;"));
+        m_cascadeStatusIconLayout->addWidget(label);
     }
+
+    m_cascadeStatusIconContainer->setVisible(m_cascadeStatusIconLayout->count() > 0);
 }
 
 QString MainWindow::iconResourceForNetwork(const Network* network) const

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -27,6 +27,8 @@ class QTableView;
 class QCPAbstractPlottable;
 class QResizeEvent;
 class QLabel;
+class QWidget;
+class QHBoxLayout;
 
 class MainWindow : public QMainWindow
 {
@@ -145,6 +147,7 @@ private:
     int m_networkFrequencyPoints;
     bool m_initialFrequencyConfigured;
 
-    QVector<QLabel*> m_cascadeStatusIconLabels;
+    QWidget* m_cascadeStatusIconContainer;
+    QHBoxLayout* m_cascadeStatusIconLayout;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary
- create a dedicated zero-spacing container in the status bar so cascade icons display flush without separators
- size each cascade status icon label to the pixmap's logical dimensions to avoid Qt scaling artifacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dade77317c83269195d0b13dcb63b5