### PR TITLE
Rename lumped LRC networks to RLC and reorder parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ fsnpview example.s2p -c example.s2p R_series R 75 -f 1e6 1e9 1001 -s result.s2p 
 ```
 
 The CLI understands the same lumped elements that are available in the
-GUI (**R/C/L**, lossy and lossless transmission lines, and the LRC
+GUI (**R/C/L**, lossy and lossless transmission lines, and the RLC
 combinations) and accepts both positional arguments and explicit
 `name=value` overrides.  Combine `-n`, `-c`, and `-s` to automate
 repeatable cascades as part of a data-processing pipeline.

--- a/commandlineparser.cpp
+++ b/commandlineparser.cpp
@@ -64,13 +64,13 @@ const QVector<LumpedDefinition>& lumpedDefinitions()
           {QStringLiteral("a"), {QStringLiteral("Alpha"), QStringLiteral("Loss"), QStringLiteral("a_dBpm")}, 3, true},
           {QStringLiteral("a_d"), {QStringLiteral("AlphaD"), QStringLiteral("Ad"), QStringLiteral("a_d_dBpm")}, 4, true},
           {QStringLiteral("fa"), {QStringLiteral("Fa"), QStringLiteral("FreqRef")}, 5, true}}},
-        {QStringLiteral("LRC_ser_shunt"), {QStringLiteral("LRCSerShunt")}, NetworkLumped::NetworkType::LRC_series_shunt,
-         {{QStringLiteral("l"), {QStringLiteral("L"), QStringLiteral("Ind")}, 0, true},
-          {QStringLiteral("r"), {QStringLiteral("R")}, 1, true},
+        {QStringLiteral("RLC_ser_shunt"), {QStringLiteral("RLCSerShunt")}, NetworkLumped::NetworkType::RLC_series_shunt,
+         {{QStringLiteral("r"), {QStringLiteral("R")}, 0, true},
+          {QStringLiteral("l"), {QStringLiteral("L"), QStringLiteral("Ind")}, 1, true},
           {QStringLiteral("c"), {QStringLiteral("C")}, 2, true}}},
-        {QStringLiteral("LRC_par_ser"), {QStringLiteral("LRCParSer")}, NetworkLumped::NetworkType::LRC_parallel_series,
-         {{QStringLiteral("l"), {QStringLiteral("L"), QStringLiteral("Ind")}, 0, true},
-          {QStringLiteral("r"), {QStringLiteral("R")}, 1, true},
+        {QStringLiteral("RLC_par_ser"), {QStringLiteral("RLCParSer")}, NetworkLumped::NetworkType::RLC_parallel_series,
+         {{QStringLiteral("r"), {QStringLiteral("R")}, 0, true},
+          {QStringLiteral("l"), {QStringLiteral("L"), QStringLiteral("Ind")}, 1, true},
           {QStringLiteral("c"), {QStringLiteral("C")}, 2, true}}}
     };
     return defs;
@@ -362,8 +362,8 @@ QString CommandLineParser::helpText() const
         "  TransmissionLine  len (mm), Z0 (Ohm), er_eff   defaults 1, 50, 1\n"
         "  TL_lossy          len (mm), Z0 (Ohm), er_eff, a (dB/m), a_d (dB/m), fa (Hz)\n"
         "                    defaults 1, 50, 1, 10, 1, 1e9\n"
-        "  LRC_ser_shunt     L (nH), R (Ohm), C (pF) defaults 1, 1e-3, 1\n"
-        "  LRC_par_ser       L (nH), R (Ohm), C (pF) defaults 1, 1e6, 1\n"
+        "  RLC_ser_shunt     R (Ohm), L (nH), C (pF) defaults 1e-3, 1, 1\n"
+        "  RLC_par_ser       R (Ohm), L (nH), C (pF) defaults 1e6, 1, 1\n"
         "\n"
         "Examples:\n"
         "  fsnpview example.s2p -c example.s2p R_series R 75\n"

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -394,8 +394,8 @@ void MainWindow::populateLumpedNetworkTable()
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::L_shunt, {1.0, 1.0}));
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::TransmissionLine, {1.0, 50.0, 1.0}));
     m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::TransmissionLineLossy, {1.0, 50.0, 1.0, 10.0, 1.0, 1e9}));
-    m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::LRC_series_shunt));
-    m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::LRC_parallel_series));
+    m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::RLC_series_shunt));
+    m_networks.append(new NetworkLumped(NetworkLumped::NetworkType::RLC_parallel_series));
 
     m_lumpedParameterCount = 0;
     for (auto network_ptr : qAsConst(m_networks)) {
@@ -842,9 +842,9 @@ QString MainWindow::iconResourceForNetwork(const Network* network) const
             return QStringLiteral("TL");
         case NetworkLumped::NetworkType::TransmissionLineLossy:
             return QStringLiteral("TL_lossy");
-        case NetworkLumped::NetworkType::LRC_series_shunt:
+        case NetworkLumped::NetworkType::RLC_series_shunt:
             return QStringLiteral("RLC_ser_shunt");
-        case NetworkLumped::NetworkType::LRC_parallel_series:
+        case NetworkLumped::NetworkType::RLC_parallel_series:
             return QStringLiteral("RLC_par_ser");
         }
     }

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -86,8 +86,8 @@ QString NetworkLumped::typeName() const
     case NetworkType::L_shunt:  return QStringLiteral("L_shunt");
     case NetworkType::TransmissionLine: return QStringLiteral("TL");
     case NetworkType::TransmissionLineLossy: return QStringLiteral("TL_lossy");
-    case NetworkType::LRC_series_shunt: return QStringLiteral("LRC_ser_shunt");
-    case NetworkType::LRC_parallel_series: return QStringLiteral("LRC_par_ser");
+    case NetworkType::RLC_series_shunt: return QStringLiteral("RLC_ser_shunt");
+    case NetworkType::RLC_parallel_series: return QStringLiteral("RLC_par_ser");
     }
     return QString();
 }
@@ -186,9 +186,9 @@ Eigen::MatrixXcd NetworkLumped::sparameters(const Eigen::VectorXd& freq) const
             abcd_point(1, 1) = cosh_term;
             break;
         }
-        case NetworkType::LRC_series_shunt: {
-            const double inductance = parameterValueSI(0);
-            const double resistance = parameterValueSI(1);
+        case NetworkType::RLC_series_shunt: {
+            const double resistance = parameterValueSI(0);
+            const double inductance = parameterValueSI(1);
             const double capacitance = parameterValueSI(2);
             std::complex<double> impedance = resistance;
             impedance += j * w * inductance;
@@ -209,9 +209,9 @@ Eigen::MatrixXcd NetworkLumped::sparameters(const Eigen::VectorXd& freq) const
             }
             break;
         }
-        case NetworkType::LRC_parallel_series: {
-            const double inductance = parameterValueSI(0);
-            const double resistance = parameterValueSI(1);
+        case NetworkType::RLC_parallel_series: {
+            const double resistance = parameterValueSI(0);
+            const double inductance = parameterValueSI(1);
             const double capacitance = parameterValueSI(2);
             std::complex<double> admittance = 0.0;
             bool infiniteAdmittance = false;
@@ -446,14 +446,14 @@ void NetworkLumped::initializeParameters(const QVector<double>& values)
         m_parameters.append({QStringLiteral("a_d_dBpm"), 1.0, 1.0});
         m_parameters.append({QStringLiteral("fa_Hz"), 1e9, 1.0});
         break;
-    case NetworkType::LRC_series_shunt:
-        m_parameters.append({QStringLiteral("L_nH"), 1.0, 1e-9});
+    case NetworkType::RLC_series_shunt:
         m_parameters.append({resistanceLabel, 1e-3, 1.0});
+        m_parameters.append({QStringLiteral("L_nH"), 1.0, 1e-9});
         m_parameters.append({QStringLiteral("C_pF"), 1.0, 1e-12});
         break;
-    case NetworkType::LRC_parallel_series:
-        m_parameters.append({QStringLiteral("L_nH"), 1.0, 1e-9});
+    case NetworkType::RLC_parallel_series:
         m_parameters.append({resistanceLabel, 1e6, 1.0});
+        m_parameters.append({QStringLiteral("L_nH"), 1.0, 1e-9});
         m_parameters.append({QStringLiteral("C_pF"), 1.0, 1e-12});
         break;
     }

--- a/networklumped.h
+++ b/networklumped.h
@@ -18,8 +18,8 @@ public:
         L_shunt,
         TransmissionLine,
         TransmissionLineLossy,
-        LRC_series_shunt,
-        LRC_parallel_series
+        RLC_series_shunt,
+        RLC_parallel_series
     };
 
     explicit NetworkLumped(NetworkType type, QObject *parent = nullptr);

--- a/tests/test_lumped_networks_cli_vs_skrf.py
+++ b/tests/test_lumped_networks_cli_vs_skrf.py
@@ -290,25 +290,25 @@ def tokens_tl_lossy(
     ]
 
 
-def tokens_lrc_series_shunt(inductance_nh: float, resistance_ohm: float, capacitance_pf: float) -> list[str]:
+def tokens_rlc_series_shunt(resistance_ohm: float, inductance_nh: float, capacitance_pf: float) -> list[str]:
     return [
-        "LRC_ser_shunt",
-        "l",
-        format_value(inductance_nh),
+        "RLC_ser_shunt",
         "r",
         format_value(resistance_ohm),
+        "l",
+        format_value(inductance_nh),
         "c",
         format_value(capacitance_pf),
     ]
 
 
-def tokens_lrc_parallel_series(inductance_nh: float, resistance_ohm: float, capacitance_pf: float) -> list[str]:
+def tokens_rlc_parallel_series(resistance_ohm: float, inductance_nh: float, capacitance_pf: float) -> list[str]:
     return [
-        "LRC_par_ser",
-        "l",
-        format_value(inductance_nh),
+        "RLC_par_ser",
         "r",
         format_value(resistance_ohm),
+        "l",
+        format_value(inductance_nh),
         "c",
         format_value(capacitance_pf),
     ]
@@ -320,10 +320,10 @@ def network_from_abcd(frequency: rf.Frequency, abcd: np.ndarray, base_name: str)
     return rename_network(network, base_name)
 
 
-def create_lrc_series_shunt(
+def create_rlc_series_shunt(
     factory: Callable[[float], DefinedGammaZ0],
-    inductance_nh: float,
     resistance_ohm: float,
+    inductance_nh: float,
     capacitance_pf: float,
     base_name: str,
 ) -> rf.Network:
@@ -353,10 +353,10 @@ def create_lrc_series_shunt(
     return network_from_abcd(frequency, abcd, base_name)
 
 
-def create_lrc_parallel_series(
+def create_rlc_parallel_series(
     factory: Callable[[float], DefinedGammaZ0],
-    inductance_nh: float,
     resistance_ohm: float,
+    inductance_nh: float,
     capacitance_pf: float,
     base_name: str,
 ) -> rf.Network:
@@ -393,24 +393,24 @@ def create_lrc_parallel_series(
     return network_from_abcd(frequency, abcd, base_name)
 
 
-def expected_lrc_series_shunt(
+def expected_rlc_series_shunt(
     factory: Callable[[float], DefinedGammaZ0],
-    inductance_nh: float,
     resistance_ohm: float,
+    inductance_nh: float,
     capacitance_pf: float,
     base_name: str,
 ) -> rf.Network:
-    return create_lrc_series_shunt(factory, inductance_nh, resistance_ohm, capacitance_pf, base_name)
+    return create_rlc_series_shunt(factory, resistance_ohm, inductance_nh, capacitance_pf, base_name)
 
 
-def expected_lrc_parallel_series(
+def expected_rlc_parallel_series(
     factory: Callable[[float], DefinedGammaZ0],
-    inductance_nh: float,
     resistance_ohm: float,
+    inductance_nh: float,
     capacitance_pf: float,
     base_name: str,
 ) -> rf.Network:
-    return create_lrc_parallel_series(factory, inductance_nh, resistance_ohm, capacitance_pf, base_name)
+    return create_rlc_parallel_series(factory, resistance_ohm, inductance_nh, capacitance_pf, base_name)
 
 
 def wrap_phase_deg(values: np.ndarray) -> np.ndarray:
@@ -678,20 +678,20 @@ def main() -> int:
             npoints=161,
         ),
         LumpedNetworkSpec(
-            name="LRC_ser_shunt",
-            cli_tokens=tokens_lrc_series_shunt(2.5, 0.002, 1.8),
-            build_expected=lambda factory: expected_lrc_series_shunt(
-                factory, 2.5, 0.002, 1.8, "LRC_ser_shunt_expected"
+            name="RLC_ser_shunt",
+            cli_tokens=tokens_rlc_series_shunt(0.002, 2.5, 1.8),
+            build_expected=lambda factory: expected_rlc_series_shunt(
+                factory, 0.002, 2.5, 1.8, "RLC_ser_shunt_expected"
             ),
             fmin_hz=1e4,
             fmax_hz=1e8,
             npoints=91,
         ),
         LumpedNetworkSpec(
-            name="LRC_par_ser",
-            cli_tokens=tokens_lrc_parallel_series(3.7, 750000.0, 2.6),
-            build_expected=lambda factory: expected_lrc_parallel_series(
-                factory, 3.7, 750000.0, 2.6, "LRC_par_ser_expected"
+            name="RLC_par_ser",
+            cli_tokens=tokens_rlc_parallel_series(750000.0, 3.7, 2.6),
+            build_expected=lambda factory: expected_rlc_parallel_series(
+                factory, 750000.0, 3.7, 2.6, "RLC_par_ser_expected"
             ),
             fmin_hz=2e3,
             fmax_hz=2e7,
@@ -931,8 +931,8 @@ def main() -> int:
                 a_d_db_per_m=0.9,
                 fa_hz=4.5e9,
             ),
-            create_lrc_series_shunt(factory, 2.1, 0.0015, 2.2, "All_types_LRC_ser_shunt"),
-            create_lrc_parallel_series(factory, 2.8, 680000.0, 1.7, "All_types_LRC_par_ser"),
+            create_rlc_series_shunt(factory, 0.0015, 2.1, 2.2, "All_types_RLC_ser_shunt"),
+            create_rlc_parallel_series(factory, 680000.0, 2.8, 1.7, "All_types_RLC_par_ser"),
         ]
         return cascade_networks(components, "All_types_cascade_expected")
 
@@ -948,8 +948,8 @@ def main() -> int:
                 + tokens_l_shunt(18.0, 0.33)
                 + tokens_transmission_line_er(0.012, 58.0, 1.7)
                 + tokens_tl_lossy(0.007, 53.0, 2.5, 6.5, 0.9, 4.5e9)
-                + tokens_lrc_series_shunt(2.1, 0.0015, 2.2)
-                + tokens_lrc_parallel_series(2.8, 680000.0, 1.7)
+                + tokens_rlc_series_shunt(0.0015, 2.1, 2.2)
+                + tokens_rlc_parallel_series(680000.0, 2.8, 1.7)
             ),
             build_expected=build_all_types_cascade,
             fmin_hz=1e7,


### PR DESCRIPTION
## Summary
- rename the LRC lumped network types to RLC throughout the application and help output
- reorder the RLC parameter definitions to use R, L, C across the GUI, CLI, and simulation code
- update the automated lumped network tests to follow the new naming and parameter order

## Testing
- pytest tests/test_lumped_networks_cli_vs_skrf.py *(fails: missing matplotlib dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dafcef165c8326b7b0b516a02ee926