### PR TITLE
Add per-parameter plot styling controls

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -128,3 +128,8 @@ g++ -std=c++17 -I/usr/include/eigen3 -I. \
     networklumped.cpp networkcascade.cpp tdrcalculator.cpp \
     moc_network.cpp moc_networkfile.cpp moc_networklumped.cpp moc_networkcascade.cpp \
     -o networkcascade_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)
+
+g++ -std=c++17 -I/usr/include/eigen3 -I. \
+    tests/network_plot_style_tests.cpp network.cpp \
+    moc_network.cpp \
+    -o network_plot_style_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)

--- a/fsnpview.pro
+++ b/fsnpview.pro
@@ -40,7 +40,8 @@ SOURCES += \
     networkitemmodel.cpp \
     plotmanager.cpp \
     tdrcalculator.cpp \
-    commandlineparser.cpp
+    commandlineparser.cpp \
+    parameterstyledialog.cpp
 
 HEADERS += \
     SmithChartGrid.h \
@@ -55,7 +56,8 @@ HEADERS += \
     networkitemmodel.h \
     plotmanager.h \
     tdrcalculator.h \
-    commandlineparser.h
+    commandlineparser.h \
+    parameterstyledialog.h
 
 FORMS += \
     mainwindow.ui

--- a/network.h
+++ b/network.h
@@ -3,11 +3,15 @@
 
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QColor>
 #include <QVector>
 #include <QPair>
+#include <QPen>
+#include <QHash>
 #include <Eigen/Dense>
 #include <complex>
+#include <optional>
 
 enum class PlotType { Magnitude, Phase, GroupDelay, VSWR, Smith, TDR };
 
@@ -60,8 +64,23 @@ public:
     bool isActive() const;
     void setActive(bool active);
 
+    QStringList parameterNames() const;
+
+    QColor parameterColor(const QString& parameter) const;
+    void setParameterColor(const QString& parameter, const QColor& color);
+
+    int parameterWidth(const QString& parameter) const;
+    void setParameterWidth(const QString& parameter, int width);
+
+    Qt::PenStyle parameterStyle(const QString& parameter) const;
+    void setParameterStyle(const QString& parameter, Qt::PenStyle style);
+
+    QPen parameterPen(const QString& parameter) const;
+
 protected:
     Eigen::ArrayXd unwrap(const Eigen::ArrayXd& phase);
+    void copyStyleSettingsFrom(const Network* other);
+    Qt::PenStyle defaultPenStyleForParameter(const QString& parameter) const;
 
     double m_fmin;
     double m_fmax;
@@ -69,6 +88,19 @@ protected:
     bool m_is_visible;
     bool m_unwrap_phase;
     bool m_is_active; // for cascade calculation
+
+private:
+    struct PenSettings
+    {
+        std::optional<QColor> color;
+        std::optional<int> width;
+        std::optional<Qt::PenStyle> style;
+    };
+
+    static QString normalizedParameterKey(const QString& parameter);
+    void updateOrRemovePenSettings(const QString& key, PenSettings&& settings);
+
+    QHash<QString, PenSettings> m_parameterPenSettings;
 };
 
 #endif // NETWORK_H

--- a/networkcascade.cpp
+++ b/networkcascade.cpp
@@ -265,6 +265,7 @@ Network* NetworkCascade::clone(QObject* parent) const
     copy->setActive(m_is_active);
     copy->setFrequencyRange(m_fmin, m_fmax, m_manualFrequencyRange);
     copy->setPointCount(m_pointCount);
+    copy->copyStyleSettingsFrom(this);
     for (const auto& net : m_networks) {
         copy->addNetwork(net->clone(copy));
     }

--- a/networkfile.cpp
+++ b/networkfile.cpp
@@ -40,6 +40,7 @@ Network* NetworkFile::clone(QObject* parent) const
     copy->setActive(m_is_active);
     copy->setFmin(m_fmin);
     copy->setFmax(m_fmax);
+    copy->copyStyleSettingsFrom(this);
     return copy;
 }
 

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -72,6 +72,7 @@ Network* NetworkLumped::clone(QObject* parent) const
     copy->setFmin(m_fmin);
     copy->setFmax(m_fmax);
     copy->setPointCount(m_pointCount);
+    copy->copyStyleSettingsFrom(this);
     return copy;
 }
 

--- a/parameterstyledialog.cpp
+++ b/parameterstyledialog.cpp
@@ -1,0 +1,223 @@
+#include "parameterstyledialog.h"
+
+#include "network.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QColorDialog>
+#include <QList>
+#include <QObject>
+
+namespace
+{
+    struct PenStyleOption
+    {
+        QString label;
+        Qt::PenStyle style;
+    };
+
+    QList<PenStyleOption> availablePenStyles()
+    {
+        return {
+            {QObject::tr("Solid"), Qt::SolidLine},
+            {QObject::tr("Dashed"), Qt::DashLine},
+            {QObject::tr("Dotted"), Qt::DotLine},
+            {QObject::tr("Dash-Dot"), Qt::DashDotLine},
+            {QObject::tr("Dash-Dot-Dot"), Qt::DashDotDotLine}
+        };
+    }
+}
+
+ParameterStyleDialog::ParameterStyleDialog(Network* network, QWidget* parent)
+    : QDialog(parent)
+    , m_network(network)
+{
+    setWindowTitle(tr("Select Color and Style"));
+    setModal(true);
+
+    if (m_network)
+        m_parameters = m_network->parameterNames();
+
+    m_parameterCombo = new QComboBox(this);
+    m_parameterCombo->addItem(tr("All Parameters"), QString());
+    for (const QString& parameter : m_parameters)
+        m_parameterCombo->addItem(parameter, parameter);
+
+    m_widthCombo = new QComboBox(this);
+    for (int i = 0; i <= 10; ++i)
+        m_widthCombo->addItem(QString::number(i), i);
+
+    m_styleCombo = new QComboBox(this);
+    for (const PenStyleOption& option : availablePenStyles())
+        m_styleCombo->addItem(option.label, static_cast<int>(option.style));
+
+    m_colorButton = new QPushButton(tr("Choose..."), this);
+    m_colorPreview = new QFrame(this);
+    m_colorPreview->setFrameShape(QFrame::Box);
+    m_colorPreview->setMinimumSize(32, 20);
+    m_colorPreview->setMaximumHeight(24);
+
+    m_buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+
+    auto colorLayout = new QHBoxLayout;
+    colorLayout->addWidget(m_colorPreview);
+    colorLayout->addWidget(m_colorButton);
+    colorLayout->addStretch(1);
+
+    auto formLayout = new QFormLayout;
+    formLayout->addRow(tr("Parameter"), m_parameterCombo);
+    formLayout->addRow(tr("Color"), colorLayout);
+    formLayout->addRow(tr("Line width"), m_widthCombo);
+    formLayout->addRow(tr("Line style"), m_styleCombo);
+
+    auto mainLayout = new QVBoxLayout(this);
+    mainLayout->addLayout(formLayout);
+    mainLayout->addWidget(m_buttonBox);
+
+    connect(m_colorButton, &QPushButton::clicked, this, &ParameterStyleDialog::chooseColor);
+    connect(m_parameterCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &ParameterStyleDialog::parameterChanged);
+    connect(m_buttonBox, &QDialogButtonBox::accepted, this, &ParameterStyleDialog::accept);
+    connect(m_buttonBox, &QDialogButtonBox::rejected, this, &ParameterStyleDialog::reject);
+
+    if (m_network)
+        m_color = m_network->color();
+    else
+        m_color = Qt::black;
+
+    updateColorPreview();
+    parameterChanged(m_parameterCombo->currentIndex());
+}
+
+QString ParameterStyleDialog::selectedParameter() const
+{
+    return m_parameterCombo->currentData().toString();
+}
+
+QColor ParameterStyleDialog::selectedColor() const
+{
+    return m_color;
+}
+
+int ParameterStyleDialog::selectedWidth() const
+{
+    return m_widthCombo->currentData().toInt();
+}
+
+Qt::PenStyle ParameterStyleDialog::selectedStyle() const
+{
+    return static_cast<Qt::PenStyle>(m_styleCombo->currentData().toInt());
+}
+
+bool ParameterStyleDialog::applyToAllParameters() const
+{
+    return selectedParameter().isEmpty();
+}
+
+void ParameterStyleDialog::chooseColor()
+{
+    QColor chosen = QColorDialog::getColor(m_color.isValid() ? m_color : Qt::white,
+                                           this, tr("Select Color"));
+    if (!chosen.isValid())
+        return;
+    m_color = chosen;
+    updateColorPreview();
+}
+
+void ParameterStyleDialog::parameterChanged(int index)
+{
+    Q_UNUSED(index);
+    if (!m_network)
+        return;
+
+    const QString parameterKey = m_parameterCombo->currentData().toString();
+    updateControlsForParameter(parameterKey);
+}
+
+void ParameterStyleDialog::updateControlsForParameter(const QString& parameterKey)
+{
+    if (!m_network)
+        return;
+
+    if (parameterKey.isEmpty())
+    {
+        m_color = m_network->color();
+
+        int uniformWidth = 0;
+        bool widthInitialized = false;
+        bool widthUniform = true;
+
+        Qt::PenStyle uniformStyle = Qt::SolidLine;
+        bool styleInitialized = false;
+        bool styleUniform = true;
+
+        for (const QString& param : m_parameters)
+        {
+            int width = m_network->parameterWidth(param);
+            Qt::PenStyle style = m_network->parameterStyle(param);
+
+            if (!widthInitialized)
+            {
+                uniformWidth = width;
+                widthInitialized = true;
+            }
+            else if (uniformWidth != width)
+            {
+                widthUniform = false;
+            }
+
+            if (!styleInitialized)
+            {
+                uniformStyle = style;
+                styleInitialized = true;
+            }
+            else if (uniformStyle != style)
+            {
+                styleUniform = false;
+            }
+        }
+
+        int widthValue = widthUniform ? uniformWidth : 0;
+        int widthIndex = m_widthCombo->findData(widthValue);
+        if (widthIndex < 0)
+            widthIndex = 0;
+        m_widthCombo->setCurrentIndex(widthIndex);
+
+        Qt::PenStyle styleValue = styleUniform ? uniformStyle : Qt::SolidLine;
+        int styleIndex = m_styleCombo->findData(static_cast<int>(styleValue));
+        if (styleIndex < 0)
+            styleIndex = 0;
+        m_styleCombo->setCurrentIndex(styleIndex);
+
+        updateColorPreview();
+        return;
+    }
+
+    m_color = m_network->parameterColor(parameterKey);
+    updateColorPreview();
+
+    int width = m_network->parameterWidth(parameterKey);
+    int widthIndex = m_widthCombo->findData(width);
+    if (widthIndex < 0)
+        widthIndex = 0;
+    m_widthCombo->setCurrentIndex(widthIndex);
+
+    Qt::PenStyle style = m_network->parameterStyle(parameterKey);
+    int styleIndex = m_styleCombo->findData(static_cast<int>(style));
+    if (styleIndex < 0)
+        styleIndex = 0;
+    m_styleCombo->setCurrentIndex(styleIndex);
+}
+
+void ParameterStyleDialog::updateColorPreview()
+{
+    QString colorName = m_color.isValid() ? m_color.name(QColor::HexRgb)
+                                          : QStringLiteral("transparent");
+    m_colorPreview->setStyleSheet(QStringLiteral("background-color: %1; border: 1px solid palette(mid);")
+                                  .arg(colorName));
+}

--- a/parameterstyledialog.h
+++ b/parameterstyledialog.h
@@ -1,0 +1,47 @@
+#ifndef PARAMETERSTYLEDIALOG_H
+#define PARAMETERSTYLEDIALOG_H
+
+#include <QDialog>
+#include <QColor>
+#include <QStringList>
+#include <QPen>
+
+class QComboBox;
+class QPushButton;
+class QDialogButtonBox;
+class QFrame;
+class Network;
+
+class ParameterStyleDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit ParameterStyleDialog(Network* network, QWidget* parent = nullptr);
+
+    QString selectedParameter() const;
+    QColor selectedColor() const;
+    int selectedWidth() const;
+    Qt::PenStyle selectedStyle() const;
+    bool applyToAllParameters() const;
+
+private slots:
+    void chooseColor();
+    void parameterChanged(int index);
+
+private:
+    void updateControlsForParameter(const QString& parameterKey);
+    void updateColorPreview();
+
+    Network* m_network;
+    QStringList m_parameters;
+    QColor m_color;
+
+    QComboBox* m_parameterCombo;
+    QComboBox* m_widthCombo;
+    QComboBox* m_styleCombo;
+    QPushButton* m_colorButton;
+    QFrame* m_colorPreview;
+    QDialogButtonBox* m_buttonBox;
+};
+
+#endif // PARAMETERSTYLEDIALOG_H

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -50,9 +50,8 @@ public slots:
 
 private:
     enum class DragMode { None, Vertical, Horizontal, Curve };
-    QCPAbstractPlottable* plot(const QVector<double> &x, const QVector<double> &y, const QColor &color,
-              const QString &name, Network* network, PlotType type,
-              Qt::PenStyle style = Qt::SolidLine);
+    QCPAbstractPlottable* plot(const QVector<double> &x, const QVector<double> &y, const QPen &pen,
+              const QString &name, Network* network, PlotType type);
     void updateTracerText(QCPItemTracer *tracer, QCPItemText *text);
     void updateTracers();
     void checkForTracerDrag(QMouseEvent *event, QCPItemTracer *tracer);

--- a/test.sh
+++ b/test.sh
@@ -58,5 +58,6 @@ make -j"$(nproc)"
 ./tdrcalculator_tests
 QT_QPA_PLATFORM=offscreen ./gui_plot_tests
 ./networkcascade_tests
+./network_plot_style_tests
 
 run_regression_test

--- a/tests/network_plot_style_tests.cpp
+++ b/tests/network_plot_style_tests.cpp
@@ -1,0 +1,93 @@
+#include "network.h"
+
+#include <QColor>
+#include <QPen>
+#include <cassert>
+#include <iostream>
+
+class DummyNetwork : public Network
+{
+public:
+    explicit DummyNetwork(int ports = 2)
+        : Network(nullptr)
+        , m_ports(ports)
+    {
+    }
+
+    QString name() const override { return QStringLiteral("dummy"); }
+    Eigen::MatrixXcd sparameters(const Eigen::VectorXd&) const override { return {}; }
+    QPair<QVector<double>, QVector<double>> getPlotData(int, PlotType) override { return {}; }
+    Network* clone(QObject* parent = nullptr) const override
+    {
+        auto* copy = new DummyNetwork(m_ports);
+        copy->setColor(m_color);
+        copy->setVisible(m_is_visible);
+        copy->setUnwrapPhase(m_unwrap_phase);
+        copy->setActive(m_is_active);
+        copy->setFmin(m_fmin);
+        copy->setFmax(m_fmax);
+        copy->copyStyleSettingsFrom(this);
+        return copy;
+    }
+    QVector<double> frequencies() const override { return {}; }
+    int portCount() const override { return m_ports; }
+
+private:
+    int m_ports;
+};
+
+void test_default_styles()
+{
+    DummyNetwork net;
+    net.setColor(Qt::red);
+
+    QPen s11Pen = net.parameterPen("s11");
+    assert(s11Pen.color() == Qt::red);
+    assert(s11Pen.width() == 0);
+    assert(s11Pen.style() == Qt::DashLine);
+
+    QPen s21Pen = net.parameterPen("s21");
+    assert(s21Pen.color() == Qt::red);
+    assert(s21Pen.width() == 0);
+    assert(s21Pen.style() == Qt::SolidLine);
+}
+
+void test_custom_styles()
+{
+    DummyNetwork net;
+    net.setColor(Qt::red);
+
+    net.setParameterColor("s21", Qt::blue);
+    net.setParameterWidth("s21", 4);
+    net.setParameterStyle("s21", Qt::DotLine);
+
+    QPen pen = net.parameterPen("s21");
+    assert(pen.color() == Qt::blue);
+    assert(pen.width() == 4);
+    assert(pen.style() == Qt::DotLine);
+
+    // Ensure values are clamped
+    net.setParameterWidth("s21", 25);
+    assert(net.parameterPen("s21").width() == 10);
+
+    // Setting defaults removes overrides
+    net.setParameterStyle("s21", Qt::SolidLine);
+    assert(net.parameterPen("s21").style() == Qt::SolidLine);
+}
+
+void test_case_insensitivity()
+{
+    DummyNetwork net;
+    net.setColor(Qt::green);
+    assert(net.parameterPen("S11").style() == Qt::DashLine);
+    assert(net.parameterPen("S21").style() == Qt::SolidLine);
+}
+
+int main()
+{
+    test_default_styles();
+    test_custom_styles();
+    test_case_insensitivity();
+    std::cout << "All network style tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- enable configuring color, width, and pen style per S-parameter via a new parameter style dialog in the color picker
- update network plotting to honor parameter-specific pens and preserve the settings when cloning networks
- extend the build with a dedicated network plot style test to verify the defaults and overrides

## Testing
- ./parser_touchstone_tests
- ./tdrcalculator_tests
- QT_QPA_PLATFORM=offscreen ./gui_plot_tests
- ./networkcascade_tests
- ./network_plot_style_tests

------
https://chatgpt.com/codex/tasks/task_e_68dc35bdc94c8326a6fa249e7846be1f