### PR TITLE
Fix ParameterStyleDialog width selection

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,6 +113,7 @@ $MOC $MOC_INCLUDES networkfile.h -o moc_networkfile.cpp
 $MOC $MOC_INCLUDES networklumped.h -o moc_networklumped.cpp
 $MOC $MOC_INCLUDES networkcascade.h -o moc_networkcascade.cpp
 $MOC $MOC_INCLUDES qcustomplot.h -o moc_qcustomplot.cpp
+$MOC $MOC_INCLUDES parameterstyledialog.h -o moc_parameterstyledialog.cpp
 
 # Build GUI plot test
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
@@ -133,3 +134,8 @@ g++ -std=c++17 -I/usr/include/eigen3 -I. \
     tests/network_plot_style_tests.cpp network.cpp \
     moc_network.cpp \
     -o network_plot_style_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)
+
+g++ -std=c++17 -I/usr/include/eigen3 -I. \
+    tests/parameter_style_dialog_tests.cpp parameterstyledialog.cpp network.cpp \
+    moc_parameterstyledialog.cpp moc_network.cpp \
+    -o parameter_style_dialog_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core)

--- a/parameterstyledialog.cpp
+++ b/parameterstyledialog.cpp
@@ -12,6 +12,7 @@
 #include <QColorDialog>
 #include <QList>
 #include <QObject>
+#include <QVariant>
 
 namespace
 {
@@ -44,15 +45,23 @@ ParameterStyleDialog::ParameterStyleDialog(Network* network, QWidget* parent)
         m_parameters = m_network->parameterNames();
 
     m_parameterCombo = new QComboBox(this);
+    m_parameterCombo->setObjectName(QStringLiteral("parameterCombo"));
     m_parameterCombo->addItem(tr("All Parameters"), QString());
     for (const QString& parameter : m_parameters)
         m_parameterCombo->addItem(parameter, parameter);
 
     m_widthCombo = new QComboBox(this);
+    m_widthCombo->setObjectName(QStringLiteral("widthCombo"));
     for (int i = 0; i <= 10; ++i)
-        m_widthCombo->addItem(QString::number(i), i);
+    {
+        const QString label = QString::number(i);
+        m_widthCombo->addItem(label);
+        const int index = m_widthCombo->count() - 1;
+        m_widthCombo->setItemData(index, i, Qt::UserRole);
+    }
 
     m_styleCombo = new QComboBox(this);
+    m_styleCombo->setObjectName(QStringLiteral("styleCombo"));
     for (const PenStyleOption& option : availablePenStyles())
         m_styleCombo->addItem(option.label, static_cast<int>(option.style));
 
@@ -106,7 +115,13 @@ QColor ParameterStyleDialog::selectedColor() const
 
 int ParameterStyleDialog::selectedWidth() const
 {
-    return m_widthCombo->currentData().toInt();
+    const QVariant widthData = m_widthCombo->currentData();
+    if (widthData.isValid())
+        return widthData.toInt();
+
+    bool ok = false;
+    const int fromText = m_widthCombo->currentText().toInt(&ok);
+    return ok ? fromText : 0;
 }
 
 Qt::PenStyle ParameterStyleDialog::selectedStyle() const

--- a/test.sh
+++ b/test.sh
@@ -59,5 +59,6 @@ make -j"$(nproc)"
 QT_QPA_PLATFORM=offscreen ./gui_plot_tests
 ./networkcascade_tests
 ./network_plot_style_tests
+QT_QPA_PLATFORM=offscreen ./parameter_style_dialog_tests
 
 run_regression_test

--- a/tests/parameter_style_dialog_tests.cpp
+++ b/tests/parameter_style_dialog_tests.cpp
@@ -1,0 +1,66 @@
+#include "parameterstyledialog.h"
+#include "network.h"
+
+#include <QApplication>
+#include <QComboBox>
+#include <QColor>
+#include <QPen>
+#include <cassert>
+#include <iostream>
+
+class DummyNetwork : public Network
+{
+public:
+    explicit DummyNetwork(int ports = 2)
+        : Network(nullptr)
+        , m_ports(ports)
+    {
+    }
+
+    QString name() const override { return QStringLiteral("dummy"); }
+    Eigen::MatrixXcd sparameters(const Eigen::VectorXd&) const override { return {}; }
+    QPair<QVector<double>, QVector<double>> getPlotData(int, PlotType) override { return {}; }
+    Network* clone(QObject* parent = nullptr) const override
+    {
+        auto* copy = new DummyNetwork(m_ports);
+        copy->setColor(m_color);
+        copy->setVisible(m_is_visible);
+        copy->setUnwrapPhase(m_unwrap_phase);
+        copy->setActive(m_is_active);
+        copy->setFmin(m_fmin);
+        copy->setFmax(m_fmax);
+        copy->copyStyleSettingsFrom(this);
+        return copy;
+    }
+    QVector<double> frequencies() const override { return {}; }
+    int portCount() const override { return m_ports; }
+
+private:
+    int m_ports;
+};
+
+int main(int argc, char** argv)
+{
+    QApplication app(argc, argv);
+
+    DummyNetwork net;
+    net.setColor(Qt::red);
+
+    ParameterStyleDialog dialog(&net);
+
+    QObject* comboObject = dialog.findChild<QObject*>("widthCombo", Qt::FindChildrenRecursively);
+    QComboBox* widthCombo = comboObject ? static_cast<QComboBox*>(comboObject) : nullptr;
+    assert(widthCombo && "Failed to locate width combo box");
+
+    const int desiredWidth = 4;
+    widthCombo->setCurrentIndex(desiredWidth);
+
+    assert(dialog.selectedWidth() == desiredWidth);
+
+    const int desiredWidthAll = 7;
+    widthCombo->setCurrentIndex(desiredWidthAll);
+    assert(dialog.selectedWidth() == desiredWidthAll);
+
+    std::cout << "Parameter style dialog tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure the line-width combobox in ParameterStyleDialog stores explicit user data and exposes object names for testing
- add a regression test that verifies selectedWidth reflects the chosen value
- update build and test scripts to build and run the new dialog test binary

## Testing
- QT_QPA_PLATFORM=offscreen ./parameter_style_dialog_tests

------
https://chatgpt.com/codex/tasks/task_e_68dc3c5271008326a39bf049630bab07