### PR TITLE
Include plot settings dialog in test builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -114,13 +114,14 @@ $MOC $MOC_INCLUDES networklumped.h -o moc_networklumped.cpp
 $MOC $MOC_INCLUDES networkcascade.h -o moc_networkcascade.cpp
 $MOC $MOC_INCLUDES qcustomplot.h -o moc_qcustomplot.cpp
 $MOC $MOC_INCLUDES parameterstyledialog.h -o moc_parameterstyledialog.cpp
+$MOC $MOC_INCLUDES plotsettingsdialog.h -o moc_plotsettingsdialog.cpp
 
 # Build GUI plot test
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
-    tests/gui_plot_tests.cpp plotmanager.cpp network.cpp networkfile.cpp \
+    tests/gui_plot_tests.cpp plotmanager.cpp plotsettingsdialog.cpp network.cpp networkfile.cpp \
     networklumped.cpp networkcascade.cpp parser_touchstone.cpp qcustomplot.cpp \
     tdrcalculator.cpp \
-    moc_plotmanager.cpp moc_network.cpp moc_networkfile.cpp moc_networklumped.cpp \
+    moc_plotmanager.cpp moc_plotsettingsdialog.cpp moc_network.cpp moc_networkfile.cpp moc_networklumped.cpp \
     moc_networkcascade.cpp moc_qcustomplot.cpp \
     -o gui_plot_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)
 
@@ -141,7 +142,7 @@ g++ -std=c++17 -I/usr/include/eigen3 -I. \
     -o parameter_style_dialog_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core)
 
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
-    tests/plotmanager_selection_tests.cpp plotmanager.cpp network.cpp networklumped.cpp \
+    tests/plotmanager_selection_tests.cpp plotmanager.cpp plotsettingsdialog.cpp network.cpp networklumped.cpp \
     networkcascade.cpp parser_touchstone.cpp qcustomplot.cpp tdrcalculator.cpp \
-    moc_plotmanager.cpp moc_network.cpp moc_networklumped.cpp moc_networkcascade.cpp moc_qcustomplot.cpp \
+    moc_plotmanager.cpp moc_plotsettingsdialog.cpp moc_network.cpp moc_networklumped.cpp moc_networkcascade.cpp moc_qcustomplot.cpp \
     -o plotmanager_selection_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1114,9 +1114,24 @@ void MainWindow::updateGraphSelectionFromTables()
 {
     QSet<Network*> selectedNetworks;
     auto collect = [&](QTableView *view, NetworkItemModel *model) {
-        const QModelIndexList rows = view->selectionModel()->selectedRows();
+        if (!view || !model)
+            return;
+        QItemSelectionModel *selectionModel = view->selectionModel();
+        if (!selectionModel)
+            return;
+
+        const QModelIndexList rows = selectionModel->selectedRows();
         for (const QModelIndex &index : rows) {
-            quintptr ptrVal = model->item(index.row(), 0)->data(Qt::UserRole).value<quintptr>();
+            if (!index.isValid())
+                continue;
+            const int row = index.row();
+            if (row < 0 || row >= model->rowCount())
+                continue;
+            QStandardItem *idItem = model->item(row, 0);
+            if (!idItem)
+                continue;
+
+            quintptr ptrVal = idItem->data(Qt::UserRole).value<quintptr>();
             Network *network = reinterpret_cast<Network*>(ptrVal);
             if (network)
                 selectedNetworks.insert(network);


### PR DESCRIPTION
## Summary
- guard the table selection aggregation against null views, invalid indices, and missing items before syncing graph selection
- prevent crashes when deleting multiple network rows by ignoring stale selections that arise during model updates
- include PlotSettingsDialog sources in the test harness so GUI test binaries link successfully

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68dc4cec886c8326abaf863aa81088c7