### PR TITLE
Improve color selection interaction

### DIFF
--- a/parameterstyledialog.h
+++ b/parameterstyledialog.h
@@ -1,15 +1,15 @@
 #ifndef PARAMETERSTYLEDIALOG_H
 #define PARAMETERSTYLEDIALOG_H
 
-#include <QDialog>
 #include <QColor>
-#include <QStringList>
+#include <QDialog>
 #include <QPen>
+#include <QStringList>
 
 class QComboBox;
-class QPushButton;
 class QDialogButtonBox;
 class QFrame;
+class QEvent;
 class Network;
 
 class ParameterStyleDialog : public QDialog
@@ -29,6 +29,7 @@ private slots:
     void parameterChanged(int index);
 
 private:
+    bool eventFilter(QObject* watched, QEvent* event) override;
     void updateControlsForParameter(const QString& parameterKey);
     void updateColorPreview();
 
@@ -39,7 +40,6 @@ private:
     QComboBox* m_parameterCombo;
     QComboBox* m_widthCombo;
     QComboBox* m_styleCombo;
-    QPushButton* m_colorButton;
     QFrame* m_colorPreview;
     QDialogButtonBox* m_buttonBox;
 };


### PR DESCRIPTION
## Summary
- remove the separate color chooser button from the parameter style dialog
- allow users to open the color picker by clicking directly on the color preview box and provide hover feedback
- ensure mouse clicks on the preview are handled via an event filter that invokes the existing color selection logic

## Testing
- not run (Qt GUI application)

------
https://chatgpt.com/codex/tasks/task_e_68dd90f5df048326a23172535c1df98b