### PR TITLE
Add grid and tick controls to plot settings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -152,3 +152,9 @@ g++ -std=c++17 -I/usr/include/eigen3 -I. \
     networkcascade.cpp parser_touchstone.cpp qcustomplot.cpp tdrcalculator.cpp \
     moc_plotmanager.cpp moc_plotsettingsdialog.cpp moc_network.cpp moc_networklumped.cpp moc_networkcascade.cpp moc_qcustomplot.cpp \
     -o plotmanager_mathplot_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)
+
+g++ -std=c++17 -I/usr/include/eigen3 -I. \
+    tests/plotsettingsdialog_tests.cpp plotmanager.cpp plotsettingsdialog.cpp network.cpp networklumped.cpp \
+    networkcascade.cpp parser_touchstone.cpp qcustomplot.cpp tdrcalculator.cpp \
+    moc_plotmanager.cpp moc_plotsettingsdialog.cpp moc_network.cpp moc_networklumped.cpp moc_networkcascade.cpp moc_qcustomplot.cpp \
+    -o plotsettingsdialog_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -36,6 +36,7 @@ public:
     QColor nextColor();
     void setXAxisScaleType(QCPAxis::ScaleType type);
     void setCrosshairEnabled(bool enabled);
+    void applySettingsFromDialog(const PlotSettingsDialog &dialog);
 
 public slots:
     void mouseDoubleClick(QMouseEvent *event);
@@ -72,11 +73,15 @@ private:
     void showPlotSettingsDialog();
     void applyAxisRanges(const PlotSettingsDialog &dialog);
     void applyMarkerPositions(const PlotSettingsDialog &dialog);
+    void applyGridSettings(const PlotSettingsDialog &dialog);
+    void applyTickSettings(const PlotSettingsDialog &dialog);
+    void applyStoredGridSettings();
     double markerValue(const QCPItemTracer *tracer) const;
     void setMarkerValue(QCPItemTracer *tracer, double value);
     void setCartesianMarkerValue(QCPItemTracer *tracer, double value);
     void setSmithMarkerFrequency(QCPItemTracer *tracer, double frequency);
     QString markerLabelText(const QString &markerName) const;
+    double currentTickStep(const QCPAxis *axis) const;
 
 
     QCustomPlot* m_plot;
@@ -102,6 +107,16 @@ private:
     bool m_crosshairEnabled;
     bool m_showPlotSettingsOnRightRelease;
     QPoint m_rightClickPressPos;
+
+    Qt::PenStyle m_gridPenStyle;
+    QColor m_gridColor;
+    Qt::PenStyle m_subGridPenStyle;
+    QColor m_subGridColor;
+
+    bool m_xTickAuto;
+    double m_xTickSpacing;
+    bool m_yTickAuto;
+    double m_yTickSpacing;
 };
 
 #endif // PLOTMANAGER_H

--- a/plotsettingsdialog.cpp
+++ b/plotsettingsdialog.cpp
@@ -1,11 +1,20 @@
 #include "plotsettingsdialog.h"
 
+#include <QCheckBox>
+#include <QColorDialog>
 #include <QDialogButtonBox>
 #include <QDoubleValidator>
 #include <QFormLayout>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
 #include <QLocale>
+#include <QComboBox>
+#include <QIcon>
+#include <QPainter>
+#include <QPixmap>
+#include <QSignalBlocker>
+#include <QToolButton>
 #include <QVBoxLayout>
 
 #include <cmath>
@@ -51,9 +60,39 @@ PlotSettingsDialog::PlotSettingsDialog(QWidget *parent)
     , m_yMaxEdit(makeLineEdit(this))
     , m_markerAEdit(makeLineEdit(this))
     , m_markerBEdit(makeLineEdit(this))
+    , m_gridStyleCombo(new QComboBox(this))
+    , m_gridColorButton(new QToolButton(this))
+    , m_gridColor(Qt::gray)
+    , m_subGridStyleCombo(new QComboBox(this))
+    , m_subGridColorButton(new QToolButton(this))
+    , m_subGridColor(Qt::gray)
+    , m_xTickSpacingEdit(makeLineEdit(this))
+    , m_xTickAutoCheck(new QCheckBox(tr("Auto"), this))
+    , m_xTickManualText()
+    , m_xTickAutoValue(0.0)
+    , m_xTickManualEnabled(true)
+    , m_yTickSpacingEdit(makeLineEdit(this))
+    , m_yTickAutoCheck(new QCheckBox(tr("Auto"), this))
+    , m_yTickManualText()
+    , m_yTickAutoValue(0.0)
+    , m_yTickManualEnabled(true)
 {
     setWindowTitle(tr("Plot Settings"));
     setModal(true);
+
+    populatePenStyleCombo(m_gridStyleCombo);
+    populatePenStyleCombo(m_subGridStyleCombo);
+
+    m_gridColorButton->setAutoRaise(true);
+    m_gridColorButton->setToolTip(tr("Select grid color"));
+    connect(m_gridColorButton, &QToolButton::clicked, this, &PlotSettingsDialog::pickGridColor);
+
+    m_subGridColorButton->setAutoRaise(true);
+    m_subGridColorButton->setToolTip(tr("Select subgrid color"));
+    connect(m_subGridColorButton, &QToolButton::clicked, this, &PlotSettingsDialog::pickSubGridColor);
+
+    updateColorIcon(m_gridColorButton, m_gridColor);
+    updateColorIcon(m_subGridColorButton, m_subGridColor);
 
     auto *formLayout = new QFormLayout;
     formLayout->addRow(m_xMinLabel, m_xMinEdit);
@@ -62,6 +101,34 @@ PlotSettingsDialog::PlotSettingsDialog(QWidget *parent)
     formLayout->addRow(m_yMaxLabel, m_yMaxEdit);
     formLayout->addRow(m_markerALabel, m_markerAEdit);
     formLayout->addRow(m_markerBLabel, m_markerBEdit);
+
+    auto *gridWidget = new QWidget(this);
+    auto *gridLayout = new QHBoxLayout(gridWidget);
+    gridLayout->setContentsMargins(0, 0, 0, 0);
+    gridLayout->addWidget(m_gridStyleCombo, /*stretch=*/1);
+    gridLayout->addWidget(m_gridColorButton, /*stretch=*/0);
+    formLayout->addRow(tr("Grid"), gridWidget);
+
+    auto *subGridWidget = new QWidget(this);
+    auto *subGridLayout = new QHBoxLayout(subGridWidget);
+    subGridLayout->setContentsMargins(0, 0, 0, 0);
+    subGridLayout->addWidget(m_subGridStyleCombo, /*stretch=*/1);
+    subGridLayout->addWidget(m_subGridColorButton, /*stretch=*/0);
+    formLayout->addRow(tr("Subgrid"), subGridWidget);
+
+    auto *xTickWidget = new QWidget(this);
+    auto *xTickLayout = new QHBoxLayout(xTickWidget);
+    xTickLayout->setContentsMargins(0, 0, 0, 0);
+    xTickLayout->addWidget(m_xTickSpacingEdit, /*stretch=*/1);
+    xTickLayout->addWidget(m_xTickAutoCheck, /*stretch=*/0);
+    formLayout->addRow(tr("X tick spacing"), xTickWidget);
+
+    auto *yTickWidget = new QWidget(this);
+    auto *yTickLayout = new QHBoxLayout(yTickWidget);
+    yTickLayout->setContentsMargins(0, 0, 0, 0);
+    yTickLayout->addWidget(m_yTickSpacingEdit, /*stretch=*/1);
+    yTickLayout->addWidget(m_yTickAutoCheck, /*stretch=*/0);
+    formLayout->addRow(tr("Y tick spacing"), yTickWidget);
 
     auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
@@ -72,6 +139,9 @@ PlotSettingsDialog::PlotSettingsDialog(QWidget *parent)
     layout->addWidget(buttonBox);
 
     setLayout(layout);
+
+    connect(m_xTickAutoCheck, &QCheckBox::toggled, this, &PlotSettingsDialog::handleXAxisAutoToggled);
+    connect(m_yTickAutoCheck, &QCheckBox::toggled, this, &PlotSettingsDialog::handleYAxisAutoToggled);
 
     setAxisLabels(QString(), QString());
     setMarkerLabelTexts(tr("Marker A"), tr("Marker B"));
@@ -119,6 +189,130 @@ void PlotSettingsDialog::setMarkerValues(double markerA, bool markerAEnabled,
     m_markerBEdit->setEnabled(markerBEnabled);
     m_markerALabel->setEnabled(markerAEnabled);
     m_markerBLabel->setEnabled(markerBEnabled);
+}
+
+void PlotSettingsDialog::setGridSettings(const QPen &gridPen, bool gridVisible,
+                                         const QPen &subGridPen, bool subGridVisible)
+{
+    Qt::PenStyle gridStyle = gridVisible ? gridPen.style() : Qt::NoPen;
+    if (!gridVisible)
+        gridStyle = Qt::NoPen;
+    if (gridStyle == Qt::NoPen && gridVisible)
+        gridStyle = Qt::SolidLine;
+
+    Qt::PenStyle subGridStyle = subGridVisible ? subGridPen.style() : Qt::NoPen;
+    if (!subGridVisible)
+        subGridStyle = Qt::NoPen;
+    if (subGridStyle == Qt::NoPen && subGridVisible)
+        subGridStyle = Qt::DotLine;
+
+    m_gridColor = gridPen.color().isValid() ? gridPen.color() : QColor(Qt::gray);
+    m_subGridColor = subGridPen.color().isValid() ? subGridPen.color() : QColor(Qt::gray);
+
+    {
+        QSignalBlocker blocker(m_gridStyleCombo);
+        int index = indexForPenStyle(m_gridStyleCombo, gridStyle);
+        if (index < 0)
+            index = indexForPenStyle(m_gridStyleCombo, Qt::DotLine);
+        if (index >= 0)
+            m_gridStyleCombo->setCurrentIndex(index);
+    }
+    {
+        QSignalBlocker blocker(m_subGridStyleCombo);
+        int index = indexForPenStyle(m_subGridStyleCombo, subGridStyle);
+        if (index < 0)
+            index = indexForPenStyle(m_subGridStyleCombo, Qt::DotLine);
+        if (index >= 0)
+            m_subGridStyleCombo->setCurrentIndex(index);
+    }
+
+    updateColorIcon(m_gridColorButton, m_gridColor);
+    updateColorIcon(m_subGridColorButton, m_subGridColor);
+}
+
+Qt::PenStyle PlotSettingsDialog::gridPenStyle() const
+{
+    Qt::PenStyle style = penStyleFromCombo(m_gridStyleCombo);
+    return style;
+}
+
+QColor PlotSettingsDialog::gridColor() const
+{
+    return m_gridColor;
+}
+
+Qt::PenStyle PlotSettingsDialog::subGridPenStyle() const
+{
+    return penStyleFromCombo(m_subGridStyleCombo);
+}
+
+QColor PlotSettingsDialog::subGridColor() const
+{
+    return m_subGridColor;
+}
+
+void PlotSettingsDialog::setXAxisTickSpacing(double manualSpacing, bool automatic,
+                                             double autoSpacingDisplayValue, bool manualControlsEnabled)
+{
+    m_xTickAutoValue = autoSpacingDisplayValue;
+    m_xTickManualEnabled = manualControlsEnabled;
+    if (std::isfinite(manualSpacing) && manualSpacing > 0.0)
+        m_xTickManualText = formatValue(manualSpacing);
+    else
+        m_xTickManualText.clear();
+
+    {
+        QSignalBlocker blocker(m_xTickAutoCheck);
+        bool shouldCheck = automatic || !manualControlsEnabled;
+        m_xTickAutoCheck->setChecked(shouldCheck);
+    }
+    m_xTickAutoCheck->setEnabled(manualControlsEnabled);
+    updateTickSpacingEdit(m_xTickSpacingEdit, m_xTickAutoCheck->isChecked(), manualControlsEnabled,
+                          m_xTickManualText, m_xTickAutoValue);
+}
+
+void PlotSettingsDialog::setYAxisTickSpacing(double manualSpacing, bool automatic,
+                                             double autoSpacingDisplayValue, bool manualControlsEnabled)
+{
+    m_yTickAutoValue = autoSpacingDisplayValue;
+    m_yTickManualEnabled = manualControlsEnabled;
+    if (std::isfinite(manualSpacing) && manualSpacing > 0.0)
+        m_yTickManualText = formatValue(manualSpacing);
+    else
+        m_yTickManualText.clear();
+
+    {
+        QSignalBlocker blocker(m_yTickAutoCheck);
+        bool shouldCheck = automatic || !manualControlsEnabled;
+        m_yTickAutoCheck->setChecked(shouldCheck);
+    }
+    m_yTickAutoCheck->setEnabled(manualControlsEnabled);
+    updateTickSpacingEdit(m_yTickSpacingEdit, m_yTickAutoCheck->isChecked(), manualControlsEnabled,
+                          m_yTickManualText, m_yTickAutoValue);
+}
+
+bool PlotSettingsDialog::xTickSpacingIsAutomatic() const
+{
+    if (!m_xTickManualEnabled)
+        return true;
+    return m_xTickAutoCheck->isChecked();
+}
+
+bool PlotSettingsDialog::yTickSpacingIsAutomatic() const
+{
+    if (!m_yTickManualEnabled)
+        return true;
+    return m_yTickAutoCheck->isChecked();
+}
+
+double PlotSettingsDialog::xTickSpacing() const
+{
+    return parseValue(m_xTickSpacingEdit, std::numeric_limits<double>::quiet_NaN());
+}
+
+double PlotSettingsDialog::yTickSpacing() const
+{
+    return parseValue(m_yTickSpacingEdit, std::numeric_limits<double>::quiet_NaN());
 }
 
 double PlotSettingsDialog::xMinimum() const
@@ -175,4 +369,129 @@ double PlotSettingsDialog::parseValue(const QLineEdit *edit, double fallback)
     bool ok = false;
     double value = edit->text().trimmed().toDouble(&ok);
     return ok ? value : fallback;
+}
+
+void PlotSettingsDialog::populatePenStyleCombo(QComboBox *combo)
+{
+    if (!combo)
+        return;
+
+    combo->clear();
+    combo->addItem(QObject::tr("None"), static_cast<int>(Qt::NoPen));
+    combo->addItem(QObject::tr("Solid"), static_cast<int>(Qt::SolidLine));
+    combo->addItem(QObject::tr("Dash"), static_cast<int>(Qt::DashLine));
+    combo->addItem(QObject::tr("Dot"), static_cast<int>(Qt::DotLine));
+    combo->addItem(QObject::tr("Dash Dot"), static_cast<int>(Qt::DashDotLine));
+    combo->addItem(QObject::tr("Dash Dot Dot"), static_cast<int>(Qt::DashDotDotLine));
+}
+
+int PlotSettingsDialog::indexForPenStyle(const QComboBox *combo, Qt::PenStyle style)
+{
+    if (!combo)
+        return -1;
+    for (int i = 0; i < combo->count(); ++i)
+    {
+        if (static_cast<Qt::PenStyle>(combo->itemData(i).toInt()) == style)
+            return i;
+    }
+    return -1;
+}
+
+Qt::PenStyle PlotSettingsDialog::penStyleFromCombo(const QComboBox *combo)
+{
+    if (!combo || combo->currentIndex() < 0)
+        return Qt::SolidLine;
+    return static_cast<Qt::PenStyle>(combo->currentData().toInt());
+}
+
+void PlotSettingsDialog::updateColorIcon(QToolButton *button, const QColor &color)
+{
+    if (!button)
+        return;
+
+    QColor effectiveColor = color.isValid() ? color : QColor(Qt::gray);
+    QPixmap pixmap(18, 18);
+    pixmap.fill(effectiveColor);
+    QPainter painter(&pixmap);
+    painter.setRenderHint(QPainter::Antialiasing, false);
+    painter.setPen(QPen(Qt::black));
+    painter.drawRect(pixmap.rect().adjusted(0, 0, -1, -1));
+    painter.end();
+    button->setIcon(QIcon(pixmap));
+    button->setIconSize(pixmap.size());
+}
+
+QString PlotSettingsDialog::effectiveManualText(const QString &manualText, double autoValue)
+{
+    if (!manualText.isEmpty())
+        return manualText;
+    return formatValue(autoValue);
+}
+
+void PlotSettingsDialog::updateTickSpacingEdit(QLineEdit *edit, bool isAuto, bool manualEnabled,
+                                               const QString &manualText, double autoValue)
+{
+    if (!edit)
+        return;
+
+    if (!manualEnabled)
+    {
+        edit->setEnabled(false);
+        edit->setText(formatValue(autoValue));
+        return;
+    }
+
+    edit->setEnabled(!isAuto);
+    if (isAuto)
+    {
+        edit->setText(formatValue(autoValue));
+    }
+    else
+    {
+        edit->setText(effectiveManualText(manualText, autoValue));
+    }
+}
+
+void PlotSettingsDialog::handleXAxisAutoToggled(bool checked)
+{
+    if (!m_xTickManualEnabled)
+    {
+        updateTickSpacingEdit(m_xTickSpacingEdit, true, false, m_xTickManualText, m_xTickAutoValue);
+        return;
+    }
+    if (checked)
+        m_xTickManualText = m_xTickSpacingEdit->text();
+    updateTickSpacingEdit(m_xTickSpacingEdit, checked, m_xTickManualEnabled,
+                          m_xTickManualText, m_xTickAutoValue);
+}
+
+void PlotSettingsDialog::handleYAxisAutoToggled(bool checked)
+{
+    if (!m_yTickManualEnabled)
+    {
+        updateTickSpacingEdit(m_yTickSpacingEdit, true, false, m_yTickManualText, m_yTickAutoValue);
+        return;
+    }
+    if (checked)
+        m_yTickManualText = m_yTickSpacingEdit->text();
+    updateTickSpacingEdit(m_yTickSpacingEdit, checked, m_yTickManualEnabled,
+                          m_yTickManualText, m_yTickAutoValue);
+}
+
+void PlotSettingsDialog::pickGridColor()
+{
+    QColor chosen = QColorDialog::getColor(m_gridColor, this, tr("Select grid color"));
+    if (!chosen.isValid())
+        return;
+    m_gridColor = chosen;
+    updateColorIcon(m_gridColorButton, m_gridColor);
+}
+
+void PlotSettingsDialog::pickSubGridColor()
+{
+    QColor chosen = QColorDialog::getColor(m_subGridColor, this, tr("Select subgrid color"));
+    if (!chosen.isValid())
+        return;
+    m_subGridColor = chosen;
+    updateColorIcon(m_subGridColorButton, m_subGridColor);
 }

--- a/plotsettingsdialog.h
+++ b/plotsettingsdialog.h
@@ -2,9 +2,14 @@
 #define PLOTSETTINGSDIALOG_H
 
 #include <QDialog>
+#include <QColor>
+#include <QPen>
 
+class QCheckBox;
+class QComboBox;
 class QLineEdit;
 class QLabel;
+class QToolButton;
 
 class PlotSettingsDialog : public QDialog
 {
@@ -19,6 +24,22 @@ public:
     void setMarkerValues(double markerA, bool markerAEnabled,
                          double markerB, bool markerBEnabled);
 
+    void setGridSettings(const QPen &gridPen, bool gridVisible,
+                         const QPen &subGridPen, bool subGridVisible);
+    Qt::PenStyle gridPenStyle() const;
+    QColor gridColor() const;
+    Qt::PenStyle subGridPenStyle() const;
+    QColor subGridColor() const;
+
+    void setXAxisTickSpacing(double manualSpacing, bool automatic,
+                             double autoSpacingDisplayValue, bool manualControlsEnabled);
+    void setYAxisTickSpacing(double manualSpacing, bool automatic,
+                             double autoSpacingDisplayValue, bool manualControlsEnabled);
+    bool xTickSpacingIsAutomatic() const;
+    bool yTickSpacingIsAutomatic() const;
+    double xTickSpacing() const;
+    double yTickSpacing() const;
+
     double xMinimum() const;
     double xMaximum() const;
     double yMinimum() const;
@@ -32,6 +53,17 @@ public:
 private:
     static QString formatValue(double value);
     static double parseValue(const QLineEdit *edit, double fallback);
+    static void populatePenStyleCombo(QComboBox *combo);
+    static int indexForPenStyle(const QComboBox *combo, Qt::PenStyle style);
+    static Qt::PenStyle penStyleFromCombo(const QComboBox *combo);
+    static void updateColorIcon(QToolButton *button, const QColor &color);
+    static QString effectiveManualText(const QString &manualText, double autoValue);
+    void updateTickSpacingEdit(QLineEdit *edit, bool isAuto, bool manualEnabled,
+                               const QString &manualText, double autoValue);
+    void handleXAxisAutoToggled(bool checked);
+    void handleYAxisAutoToggled(bool checked);
+    void pickGridColor();
+    void pickSubGridColor();
 
     QLabel *m_xMinLabel;
     QLabel *m_xMaxLabel;
@@ -46,6 +78,26 @@ private:
     QLineEdit *m_yMaxEdit;
     QLineEdit *m_markerAEdit;
     QLineEdit *m_markerBEdit;
+
+    QComboBox *m_gridStyleCombo;
+    QToolButton *m_gridColorButton;
+    QColor m_gridColor;
+
+    QComboBox *m_subGridStyleCombo;
+    QToolButton *m_subGridColorButton;
+    QColor m_subGridColor;
+
+    QLineEdit *m_xTickSpacingEdit;
+    QCheckBox *m_xTickAutoCheck;
+    QString m_xTickManualText;
+    double m_xTickAutoValue;
+    bool m_xTickManualEnabled;
+
+    QLineEdit *m_yTickSpacingEdit;
+    QCheckBox *m_yTickAutoCheck;
+    QString m_yTickManualText;
+    double m_yTickAutoValue;
+    bool m_yTickManualEnabled;
 };
 
 #endif // PLOTSETTINGSDIALOG_H

--- a/test.sh
+++ b/test.sh
@@ -62,5 +62,6 @@ QT_QPA_PLATFORM=offscreen ./gui_plot_tests
 QT_QPA_PLATFORM=offscreen ./parameter_style_dialog_tests
 QT_QPA_PLATFORM=offscreen ./plotmanager_selection_tests
 QT_QPA_PLATFORM=offscreen ./plotmanager_mathplot_tests
+QT_QPA_PLATFORM=offscreen ./plotsettingsdialog_tests
 
 run_regression_test

--- a/tests/plotsettingsdialog_tests.cpp
+++ b/tests/plotsettingsdialog_tests.cpp
@@ -1,0 +1,109 @@
+#include <QApplication>
+#include <QSharedPointer>
+#include <QPen>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+#include "plotmanager.h"
+#include "plotsettingsdialog.h"
+#include "qcustomplot.h"
+
+static void test_manual_grid_and_ticks()
+{
+    QCustomPlot plot;
+    PlotManager manager(&plot);
+
+    plot.xAxis->setRange(0.0, 100.0);
+    plot.yAxis->setRange(-10.0, 10.0);
+
+    PlotSettingsDialog dialog(&plot);
+    QPen gridPen(Qt::blue);
+    gridPen.setStyle(Qt::DashLine);
+    gridPen.setWidthF(0.0);
+    QPen subGridPen(Qt::green);
+    subGridPen.setStyle(Qt::DotLine);
+    subGridPen.setWidthF(0.0);
+    dialog.setGridSettings(gridPen, true, subGridPen, true);
+    dialog.setXAxisTickSpacing(5.0, false, 0.0, true);
+    dialog.setYAxisTickSpacing(2.5, false, 0.0, true);
+
+    manager.applySettingsFromDialog(dialog);
+
+    QCPGrid *xGrid = plot.xAxis->grid();
+    QCPGrid *yGrid = plot.yAxis->grid();
+    assert(xGrid && yGrid);
+    assert(xGrid->visible());
+    assert(yGrid->visible());
+    assert(xGrid->pen().style() == Qt::DashLine);
+    assert(yGrid->pen().style() == Qt::DashLine);
+    assert(xGrid->pen().color() == Qt::blue);
+    assert(yGrid->pen().color() == Qt::blue);
+    assert(xGrid->subGridVisible());
+    assert(yGrid->subGridVisible());
+    assert(xGrid->subGridPen().style() == Qt::DotLine);
+    assert(yGrid->subGridPen().style() == Qt::DotLine);
+    assert(xGrid->subGridPen().color() == Qt::green);
+    assert(yGrid->subGridPen().color() == Qt::green);
+
+    auto xTicker = plot.xAxis->ticker();
+    auto yTicker = plot.yAxis->ticker();
+    auto fixedXTicker = qSharedPointerDynamicCast<QCPAxisTickerFixed>(xTicker);
+    auto fixedYTicker = qSharedPointerDynamicCast<QCPAxisTickerFixed>(yTicker);
+    assert(fixedXTicker);
+    assert(fixedYTicker);
+    assert(std::abs(fixedXTicker->tickStep() - 5.0) < 1e-9);
+    assert(std::abs(fixedYTicker->tickStep() - 2.5) < 1e-9);
+
+    PlotSettingsDialog disableDialog(&plot);
+    disableDialog.setGridSettings(gridPen, false, subGridPen, false);
+    disableDialog.setXAxisTickSpacing(5.0, true, 1.0, true);
+    disableDialog.setYAxisTickSpacing(2.5, true, 1.0, true);
+
+    manager.applySettingsFromDialog(disableDialog);
+
+    assert(!plot.xAxis->grid()->visible());
+    assert(!plot.yAxis->grid()->visible());
+    assert(!plot.xAxis->grid()->subGridVisible());
+    assert(!plot.yAxis->grid()->subGridVisible());
+
+    auto autoXTicker = qSharedPointerDynamicCast<QCPAxisTickerFixed>(plot.xAxis->ticker());
+    auto autoYTicker = qSharedPointerDynamicCast<QCPAxisTickerFixed>(plot.yAxis->ticker());
+    assert(!autoXTicker);
+    assert(!autoYTicker);
+}
+
+static void test_invalid_manual_spacing_falls_back_to_auto()
+{
+    QCustomPlot plot;
+    PlotManager manager(&plot);
+    plot.xAxis->setRange(0.0, 1.0);
+    plot.yAxis->setRange(0.0, 1.0);
+
+    PlotSettingsDialog dialog(&plot);
+    dialog.setGridSettings(QPen(Qt::gray), true, QPen(Qt::gray), false);
+    dialog.setXAxisTickSpacing(-1.0, false, 0.0, true);
+    dialog.setYAxisTickSpacing(std::numeric_limits<double>::quiet_NaN(), false, 0.0, true);
+
+    manager.applySettingsFromDialog(dialog);
+
+    auto xTicker = plot.xAxis->ticker();
+    auto yTicker = plot.yAxis->ticker();
+    auto fixedXTicker = qSharedPointerDynamicCast<QCPAxisTickerFixed>(xTicker);
+    auto fixedYTicker = qSharedPointerDynamicCast<QCPAxisTickerFixed>(yTicker);
+    assert(!fixedXTicker);
+    assert(!fixedYTicker);
+}
+
+int main(int argc, char **argv)
+{
+    qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
+    QApplication app(argc, argv);
+
+    test_manual_grid_and_ticks();
+    test_invalid_manual_spacing_falls_back_to_auto();
+
+    std::cout << "Plot settings dialog tests passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add grid style/color controls and manual tick spacing inputs to the plot settings dialog
- persist grid/tick configuration in the plot manager and update ticker selection logic for manual spacing
- create automated coverage for the new dialog behavior

## Testing
- `QT_QPA_PLATFORM=offscreen ./plotsettingsdialog_tests`


------
https://chatgpt.com/codex/tasks/task_e_68dd9303a2808326ae33b24c61c1f26d