### PR TITLE
Add cascade save shortcut and shared Touchstone export utilities

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -132,6 +132,12 @@ g++ -std=c++17 -I/usr/include/eigen3 -I. \
     -o networkcascade_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)
 
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
+    tests/cascadeio_tests.cpp cascadeio.cpp parser_touchstone.cpp network.cpp networkfile.cpp \
+    networklumped.cpp networkcascade.cpp tdrcalculator.cpp \
+    moc_network.cpp moc_networkfile.cpp moc_networklumped.cpp moc_networkcascade.cpp \
+    -o cascadeio_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)
+
+g++ -std=c++17 -I/usr/include/eigen3 -I. \
     tests/network_plot_style_tests.cpp network.cpp \
     moc_network.cpp \
     -o network_plot_style_tests $(pkg-config --cflags --libs Qt6Core Qt6Gui)

--- a/cascadeio.cpp
+++ b/cascadeio.cpp
@@ -1,0 +1,74 @@
+#include "cascadeio.h"
+
+#include "networkcascade.h"
+#include "parser_touchstone.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QByteArray>
+
+#include <exception>
+
+bool saveCascadeToFile(const NetworkCascade& cascade,
+                       const Eigen::VectorXd& freq,
+                       QString path,
+                       QString* savedAbsolutePath,
+                       QString* errorMessage)
+{
+    if (freq.size() == 0) {
+        if (errorMessage)
+            *errorMessage = QStringLiteral("Cannot save cascade: no frequency points available.");
+        return false;
+    }
+
+    const int ports = cascade.portCount();
+    if (ports <= 0) {
+        if (errorMessage)
+            *errorMessage = QStringLiteral("Cannot save cascade: invalid port count.");
+        return false;
+    }
+
+    ts::TouchstoneData data;
+    data.ports = ports;
+    data.parameter = "S";
+    data.format = "RI";
+    data.freq_unit = "HZ";
+    data.R = 50.0;
+    data.freq = freq;
+
+    const Eigen::Index rows = freq.size();
+    const Eigen::Index cols = static_cast<Eigen::Index>(ports * ports);
+    data.sparams.resize(rows, cols);
+    data.sparams.setZero();
+
+    Eigen::MatrixXcd s_matrix = cascade.sparameters(freq);
+    for (Eigen::Index row = 0; row < rows; ++row) {
+        for (Eigen::Index col = 0; col < cols && col < s_matrix.cols(); ++col) {
+            data.sparams(row, col) = s_matrix(row, col);
+        }
+    }
+
+    if (!path.endsWith(QStringLiteral(".s2p"), Qt::CaseInsensitive)) {
+        path += QStringLiteral(".s2p");
+    }
+
+    QFileInfo info(path);
+    const QString absolutePath = info.absoluteFilePath();
+
+    try {
+        const QByteArray encoded = QFile::encodeName(absolutePath);
+        ts::write_touchstone(data, std::string(encoded.constData()));
+    } catch (const std::exception& ex) {
+        if (errorMessage)
+            *errorMessage = QStringLiteral("Failed to save cascade: %1").arg(QString::fromLocal8Bit(ex.what()));
+        return false;
+    }
+
+    if (savedAbsolutePath)
+        *savedAbsolutePath = absolutePath;
+
+    if (errorMessage)
+        errorMessage->clear();
+
+    return true;
+}

--- a/cascadeio.h
+++ b/cascadeio.h
@@ -1,0 +1,15 @@
+#ifndef CASCADEIO_H
+#define CASCADEIO_H
+
+#include <QString>
+#include <Eigen/Dense>
+
+class NetworkCascade;
+
+bool saveCascadeToFile(const NetworkCascade& cascade,
+                       const Eigen::VectorXd& freq,
+                       QString path,
+                       QString* savedAbsolutePath = nullptr,
+                       QString* errorMessage = nullptr);
+
+#endif // CASCADEIO_H

--- a/fsnpview.pro
+++ b/fsnpview.pro
@@ -42,7 +42,8 @@ SOURCES += \
     tdrcalculator.cpp \
     commandlineparser.cpp \
     parameterstyledialog.cpp \
-    plotsettingsdialog.cpp
+    plotsettingsdialog.cpp \
+    cascadeio.cpp
 
 HEADERS += \
     SmithChartGrid.h \
@@ -59,7 +60,8 @@ HEADERS += \
     tdrcalculator.h \
     commandlineparser.h \
     parameterstyledialog.h \
-    plotsettingsdialog.h
+    plotsettingsdialog.h \
+    cascadeio.h
 
 FORMS += \
     mainwindow.ui

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -19,6 +19,7 @@ QT_END_NAMESPACE
 #include "networkcascade.h"
 #include "networkitemmodel.h"
 #include <memory>
+#include <Eigen/Dense>
 
 class Server;
 class NetworkFile;
@@ -47,6 +48,7 @@ public:
 
 private slots:
     void on_actionOpen_triggered();
+    void onSaveCascadeTriggered();
     void on_pushButtonAutoscale_clicked();
     void onFilesReceived(const QStringList &files);
 
@@ -101,6 +103,7 @@ private:
     void updatePlots();
     void setupModels();
     void setupViews();
+    void setupShortcuts();
     void setupTableColumns(QTableView* view);
     void updateNetworkTablesGeometry();
     int adjustTableViewToContents(QTableView* view);
@@ -120,6 +123,7 @@ private:
     void updateCascadeStatusIcons();
     QString iconResourceForNetwork(const Network* network) const;
     void updateCascadeColorColumn();
+    Eigen::VectorXd cascadeFrequencyVector() const;
 
 
     Ui::MainWindow *ui;

--- a/test.sh
+++ b/test.sh
@@ -58,6 +58,7 @@ make -j"$(nproc)"
 ./tdrcalculator_tests
 QT_QPA_PLATFORM=offscreen ./gui_plot_tests
 ./networkcascade_tests
+./cascadeio_tests
 ./network_plot_style_tests
 QT_QPA_PLATFORM=offscreen ./parameter_style_dialog_tests
 QT_QPA_PLATFORM=offscreen ./plotmanager_selection_tests

--- a/tests/cascadeio_tests.cpp
+++ b/tests/cascadeio_tests.cpp
@@ -1,0 +1,79 @@
+#include "cascadeio.h"
+#include "networkcascade.h"
+#include "networkfile.h"
+#include "parser_touchstone.h"
+
+#include <QTemporaryDir>
+#include <QFileInfo>
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+
+int main()
+{
+    NetworkFile net(QStringLiteral("test/a (1).s2p"));
+    if (net.portCount() <= 0) {
+        std::cerr << "Failed to load network fixture" << std::endl;
+        return 1;
+    }
+
+    net.setVisible(true);
+    net.setActive(true);
+
+    NetworkCascade cascade;
+    cascade.addNetwork(&net);
+
+    Eigen::VectorXd freq = Eigen::VectorXd::LinSpaced(5, net.fmin(), net.fmax());
+
+    QTemporaryDir tempDir;
+    if (!tempDir.isValid()) {
+        std::cerr << "Failed to create temporary directory" << std::endl;
+        return 1;
+    }
+
+    QString outputPath = tempDir.path() + QStringLiteral("/result");
+    QString savedPath;
+    QString errorMessage;
+    if (!saveCascadeToFile(cascade, freq, outputPath, &savedPath, &errorMessage)) {
+        std::cerr << errorMessage.toStdString() << std::endl;
+        return 1;
+    }
+
+    if (!QFileInfo::exists(savedPath)) {
+        std::cerr << "Expected saved file to exist" << std::endl;
+        return 1;
+    }
+
+    ts::TouchstoneData data = ts::parse_touchstone(savedPath.toStdString());
+    if (data.ports != cascade.portCount()) {
+        std::cerr << "Port count mismatch" << std::endl;
+        return 1;
+    }
+
+    if (data.freq.size() != freq.size()) {
+        std::cerr << "Frequency vector size mismatch" << std::endl;
+        return 1;
+    }
+
+    for (Eigen::Index i = 0; i < freq.size(); ++i) {
+        if (std::abs(data.freq(i) - freq(i)) > 1e-6) {
+            std::cerr << "Frequency mismatch at index " << i << std::endl;
+            return 1;
+        }
+    }
+
+    QString failureError;
+    if (saveCascadeToFile(cascade, Eigen::VectorXd(), outputPath, nullptr, &failureError)) {
+        std::cerr << "Expected failure when saving without frequency vector" << std::endl;
+        return 1;
+    }
+
+    if (failureError.isEmpty()) {
+        std::cerr << "Expected an error message for failed save" << std::endl;
+        return 1;
+    }
+
+    cascade.clearNetworks();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace the File menu with keyboard shortcuts for opening files and saving the current cascade
- add a shared cascade Touchstone writer that is reused by both the CLI and GUI paths
- cover the new writer with a dedicated test and hook it into the existing build script

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68dd969d0db483269f95a1aba7b69078