### PR TITLE
Fix S-parameter selection order for plotting

### DIFF
--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -722,7 +722,7 @@ void PlotManager::updatePlots(const QStringList& sparams, PlotType type)
         if (outputPort < 1 || inputPort < 1 || outputPort > ports || inputPort > ports)
             return -1;
 
-        return (inputPort - 1) * ports + (outputPort - 1);
+        return (outputPort - 1) * ports + (inputPort - 1);
     };
 
     for (const auto& sparam : sparams) {

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -167,7 +167,7 @@ void test_transmission_line_group_delay()
     transmissionLine.setFmax(10e6);
     transmissionLine.setPointCount(11);
 
-    const auto groupDelay = transmissionLine.getPlotData(1, PlotType::GroupDelay);
+    const auto groupDelay = transmissionLine.getPlotData(2, PlotType::GroupDelay);
     assert(!groupDelay.first.isEmpty());
     assert(groupDelay.first.size() == groupDelay.second.size());
 
@@ -199,7 +199,7 @@ void test_cascade_group_delay_adds_line_lengths()
     cascade.addNetwork(&line1);
     cascade.addNetwork(&line2);
 
-    const auto cascadeDelay = cascade.getPlotData(1, PlotType::GroupDelay);
+    const auto cascadeDelay = cascade.getPlotData(2, PlotType::GroupDelay);
     assert(!cascadeDelay.first.isEmpty());
     assert(cascadeDelay.first.size() == cascadeDelay.second.size());
 

--- a/tests/plotmanager_mathplot_tests.cpp
+++ b/tests/plotmanager_mathplot_tests.cpp
@@ -31,7 +31,7 @@ public:
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override
     {
         Q_UNUSED(type);
-        if (s_param_idx != 1)
+        if (s_param_idx != 2)
             return {};
         return {m_freq, m_values};
     }

--- a/tests/plotmanager_selection_tests.cpp
+++ b/tests/plotmanager_selection_tests.cpp
@@ -28,7 +28,7 @@ public:
     QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override
     {
         (void)type;
-        if (s_param_idx != 1)
+        if (s_param_idx != 2)
             return {};
         return {QVector<double>{1.0, 2.0}, QVector<double>{-1.0, -2.0}};
     }


### PR DESCRIPTION
## Summary
- adjust PlotManager's S-parameter index calculation to match the matrix layout used by network responses
- update PlotManager and cascade tests to use the corrected transmission (S21) column index

## Testing
- not run (Qt 6 runtime libraries are unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68dd993c98d883269819ba42fca9f44b