### PR TITLE
Fix phase wrapping for reflection plots in lumped networks

### DIFF
--- a/network.cpp
+++ b/network.cpp
@@ -368,3 +368,24 @@ Eigen::ArrayXd Network::computeGroupDelay(const Eigen::ArrayXd& phase_rad, const
 
     return delay;
 }
+
+Eigen::ArrayXd Network::wrapToMinusPiPi(const Eigen::ArrayXd& phase_rad)
+{
+    Eigen::ArrayXd wrapped = phase_rad;
+    const double pi = M_PI;
+    const double twoPi = 2.0 * M_PI;
+    constexpr double tolerance = 1e-12;
+    for (int i = 0; i < wrapped.size(); ++i) {
+        double value = wrapped(i);
+        if (!std::isfinite(value))
+            continue;
+        while (value < -pi - tolerance)
+            value += twoPi;
+        while (value > pi + tolerance)
+            value -= twoPi;
+        if (value >= pi - tolerance)
+            value -= twoPi;
+        wrapped(i) = value;
+    }
+    return wrapped;
+}

--- a/network.h
+++ b/network.h
@@ -26,6 +26,7 @@ public:
     static Eigen::Vector4cd abcd2s(const Eigen::Matrix2cd& abcd, double z0 = 50.0);
     static QString formatEngineering(double value, bool padMantissa = true);
     static Eigen::ArrayXd computeGroupDelay(const Eigen::ArrayXd& phase_rad, const Eigen::ArrayXd& freq_hz);
+    static Eigen::ArrayXd wrapToMinusPiPi(const Eigen::ArrayXd& phase_rad);
 
     virtual QString name() const = 0;
     virtual QString displayName() const;

--- a/networkcascade.cpp
+++ b/networkcascade.cpp
@@ -217,7 +217,7 @@ QPair<QVector<double>, QVector<double>> NetworkCascade::getPlotData(int s_param_
         return qMakePair(freqVector, values);
     }
     case PlotType::Phase: {
-        Eigen::ArrayXd phase_rad = sparam.arg();
+        Eigen::ArrayXd phase_rad = Network::wrapToMinusPiPi(sparam.arg());
         if (m_unwrap_phase)
             phase_rad = unwrap(phase_rad);
         Eigen::ArrayXd phase_deg = phase_rad * (180.0 / pi);
@@ -225,7 +225,7 @@ QPair<QVector<double>, QVector<double>> NetworkCascade::getPlotData(int s_param_
         return qMakePair(freqVector, values);
     }
     case PlotType::GroupDelay: {
-        Eigen::ArrayXd phase_rad = sparam.arg();
+        Eigen::ArrayXd phase_rad = Network::wrapToMinusPiPi(sparam.arg());
         if (m_unwrap_phase)
             phase_rad = unwrap(phase_rad);
         Eigen::ArrayXd delay = Network::computeGroupDelay(phase_rad, freq.array());

--- a/networkfile.cpp
+++ b/networkfile.cpp
@@ -98,7 +98,7 @@ QPair<QVector<double>, QVector<double>> NetworkFile::getPlotData(int s_param_idx
     case PlotType::Phase:
     {
         xValues = m_data->freq;
-        Eigen::ArrayXd phase_rad = s_param_col.arg();
+        Eigen::ArrayXd phase_rad = Network::wrapToMinusPiPi(s_param_col.arg());
         Eigen::ArrayXd unwrapped_phase_rad = m_unwrap_phase ? unwrap(phase_rad) : phase_rad;
         yValues = unwrapped_phase_rad * (180.0 / M_PI);
         break;
@@ -106,7 +106,7 @@ QPair<QVector<double>, QVector<double>> NetworkFile::getPlotData(int s_param_idx
     case PlotType::GroupDelay:
     {
         xValues = m_data->freq;
-        Eigen::ArrayXd phase_rad = s_param_col.arg();
+        Eigen::ArrayXd phase_rad = Network::wrapToMinusPiPi(s_param_col.arg());
         Eigen::ArrayXd unwrapped_phase_rad = m_unwrap_phase ? unwrap(phase_rad) : phase_rad;
         yValues = Network::computeGroupDelay(unwrapped_phase_rad, xValues);
         break;

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -305,7 +305,7 @@ QPair<QVector<double>, QVector<double>> NetworkLumped::getPlotData(int s_param_i
         return qMakePair(freqVector, values);
     }
     case PlotType::Phase: {
-        Eigen::ArrayXd phase_rad = sparam.arg();
+        Eigen::ArrayXd phase_rad = Network::wrapToMinusPiPi(sparam.arg());
         if (m_unwrap_phase)
             phase_rad = unwrap(phase_rad);
         Eigen::ArrayXd phase_deg = phase_rad * (180.0 / pi);
@@ -313,7 +313,7 @@ QPair<QVector<double>, QVector<double>> NetworkLumped::getPlotData(int s_param_i
         return qMakePair(freqVector, values);
     }
     case PlotType::GroupDelay: {
-        Eigen::ArrayXd phase_rad = sparam.arg();
+        Eigen::ArrayXd phase_rad = Network::wrapToMinusPiPi(sparam.arg());
         if (m_unwrap_phase)
             phase_rad = unwrap(phase_rad);
         Eigen::ArrayXd delay = Network::computeGroupDelay(phase_rad, freq.array());

--- a/tests/networkcascade_tests.cpp
+++ b/tests/networkcascade_tests.cpp
@@ -37,6 +37,29 @@ void test_cascade_two_files()
     assert(close(s_matrix(0, 3), s22_expected));
 }
 
+void test_wrap_to_minus_pi_pi()
+{
+    Eigen::ArrayXd values(5);
+    values << M_PI, -M_PI, M_PI + 1e-10, -M_PI - 1e-10, M_PI - 1e-10;
+    Eigen::ArrayXd wrapped = Network::wrapToMinusPiPi(values);
+
+    constexpr double pi = M_PI;
+    constexpr double tol = 1e-9;
+
+    auto inRange = [&](double angle) {
+        return angle <= pi + tol && angle >= -pi - tol;
+    };
+
+    assert(std::abs(wrapped(0) + pi) <= tol);
+    assert(std::abs(wrapped(1) + pi) <= tol);
+    assert(std::abs(wrapped(2) + pi) <= tol);
+    assert(std::abs(wrapped(3) + pi) <= tol);
+    assert(std::abs(wrapped(4) - (pi - 1e-10)) <= tol);
+
+    for (int i = 0; i < wrapped.size(); ++i)
+        assert(inRange(wrapped(i)));
+}
+
 namespace {
 constexpr double pi = 3.14159265358979323846;
 
@@ -243,6 +266,7 @@ void test_cascade_phase_unwrap_matches_manual()
 
 int main()
 {
+    test_wrap_to_minus_pi_pi();
     test_cascade_two_files();
     test_phase_unwrap_toggle();
     test_lumped_frequency_point_count();


### PR DESCRIPTION
## Summary
- normalize S-parameter phase samples to the (-π, π] range before unwrapping so reflection plots stay continuous
- add Network::wrapToMinusPiPi and use it across lumped, cascade, and file-backed networks for phase and group delay data
- cover the new helper with a regression test to guard the boundary behaviour

## Testing
- not run (Qt libraries unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dd9ef6fc308326b4686d5e97d7e8bb