### PR TITLE
Preserve plot axis state and improve smith chart behavior

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -112,7 +112,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->splitter_3->setStretchFactor(1, 1);
     ui->splitter_2->setStretchFactor(0, 0);
     ui->splitter_2->setStretchFactor(1, 1);
-    ui->checkBoxCrossHair->setChecked(true);
+    ui->checkBoxCrossHair->setChecked(false);
     m_plot_manager = new PlotManager(ui->widgetGraph, this);
     m_cascade->setColor(Qt::magenta);
 

--- a/plotmanager.cpp
+++ b/plotmanager.cpp
@@ -67,9 +67,10 @@ PlotManager::PlotManager(QCustomPlot* plot, QObject *parent)
     , m_color_index(0)
     , m_keepAspectConnected(false)
     , m_currentPlotType(PlotType::Magnitude)
-    , m_crosshairEnabled(true)
+    , m_crosshairEnabled(false)
     , m_showPlotSettingsOnRightRelease(false)
     , m_rightClickPressPos()
+    , m_restoringAxisState(false)
     , m_gridPenStyle(Qt::DotLine)
     , m_gridColor(QColor(200, 200, 200))
     , m_subGridPenStyle(Qt::NoPen)
@@ -85,6 +86,9 @@ PlotManager::PlotManager(QCustomPlot* plot, QObject *parent)
     connect(m_plot, &QCustomPlot::mouseMove, this, &PlotManager::mouseMove);
     connect(m_plot, &QCustomPlot::mouseRelease, this, &PlotManager::mouseRelease);
     connect(m_plot, &QCustomPlot::selectionChangedByUser, this, &PlotManager::selectionChanged);
+    connect(m_plot->xAxis, SIGNAL(rangeChanged(QCPRange)), this, SLOT(handleAxisRangeChanged(QCPRange)));
+    connect(m_plot->yAxis, SIGNAL(rangeChanged(QCPRange)), this, SLOT(handleAxisRangeChanged(QCPRange)));
+    connect(m_plot, &QCustomPlot::beforeReplot, this, &PlotManager::handleBeforeReplot);
 
     m_plot->setSelectionRectMode(QCP::srmZoom);
     m_plot->setRangeDragButton(Qt::RightButton);
@@ -563,6 +567,7 @@ void PlotManager::updatePlots(const QStringList& sparams, PlotType type)
     qDebug() << "  updatePlots()";
 #endif
     PlotType previousPlotType = m_currentPlotType;
+    storeAxisState(previousPlotType);
 
     auto suffixForType = [](PlotType plotType) -> QString
     {
@@ -699,6 +704,8 @@ void PlotManager::updatePlots(const QStringList& sparams, PlotType type)
         m_plot->xAxis->grid()->setVisible(true);
         m_plot->yAxis->grid()->setVisible(true);
     }
+
+    applyStoredAxisState(type);
 
     bool cascadeHasActive = false;
     if (m_cascade) {
@@ -1081,12 +1088,8 @@ void PlotManager::updatePlots(const QStringList& sparams, PlotType type)
 
     updateMathPlots();
 
-    m_plot->replot();
-    selectionChanged();
-    updateTracers();
-
     if (type == PlotType::Smith) {
-        m_plot->xAxis->setScaleRatio(m_plot->yAxis, 1.0);
+        enforceSmithAspectRatio();
         if (!m_keepAspectConnected) {
             connect(m_plot->xAxis, SIGNAL(rangeChanged(QCPRange)), this, SLOT(keepAspectRatio()));
             connect(m_plot->yAxis, SIGNAL(rangeChanged(QCPRange)), this, SLOT(keepAspectRatio()));
@@ -1097,6 +1100,10 @@ void PlotManager::updatePlots(const QStringList& sparams, PlotType type)
         disconnect(m_plot->yAxis, SIGNAL(rangeChanged(QCPRange)), this, SLOT(keepAspectRatio()));
         m_keepAspectConnected = false;
     }
+
+    m_plot->replot();
+    selectionChanged();
+    updateTracers();
 }
 
 void PlotManager::autoscale()
@@ -1973,7 +1980,88 @@ void PlotManager::selectionChanged()
 
 void PlotManager::keepAspectRatio()
 {
+    enforceSmithAspectRatio();
+}
+
+void PlotManager::enforceSmithAspectRatio()
+{
+    if (!m_plot)
+        return;
+
     m_plot->xAxis->setScaleRatio(m_plot->yAxis, 1.0);
+}
+
+void PlotManager::storeAxisState(PlotType type)
+{
+    if (!m_plot)
+        return;
+
+    const QCPRange xRange = m_plot->xAxis->range();
+    const QCPRange yRange = m_plot->yAxis->range();
+
+    if (!std::isfinite(xRange.lower) || !std::isfinite(xRange.upper) ||
+        !std::isfinite(yRange.lower) || !std::isfinite(yRange.upper))
+        return;
+
+    if (xRange.size() <= 0 || yRange.size() <= 0)
+        return;
+
+    AxisState &state = m_axisStates[type];
+    state.xRange = xRange;
+    state.yRange = yRange;
+    state.valid = true;
+}
+
+bool PlotManager::applyStoredAxisState(PlotType type)
+{
+    if (!m_plot)
+        return false;
+
+    auto it = m_axisStates.constFind(type);
+    if (it == m_axisStates.constEnd() || !it->valid)
+        return false;
+
+    const AxisState state = it.value();
+    m_restoringAxisState = true;
+    m_plot->xAxis->setRange(state.xRange);
+    m_plot->yAxis->setRange(state.yRange);
+    m_restoringAxisState = false;
+
+    m_axisStates[type] = state;
+
+    return true;
+}
+
+void PlotManager::handleAxisRangeChanged(const QCPRange &newRange)
+{
+    if (m_restoringAxisState)
+        return;
+
+    if (!std::isfinite(newRange.lower) || !std::isfinite(newRange.upper) || newRange.size() <= 0)
+        return;
+
+    QCPAxis *axis = qobject_cast<QCPAxis*>(sender());
+    if (!axis)
+        return;
+
+    AxisState &state = m_axisStates[m_currentPlotType];
+    if (axis->orientation() == Qt::Horizontal)
+        state.xRange = newRange;
+    else
+        state.yRange = newRange;
+
+    if (std::isfinite(state.xRange.lower) && std::isfinite(state.xRange.upper) &&
+        std::isfinite(state.yRange.lower) && std::isfinite(state.yRange.upper) &&
+        state.xRange.size() > 0 && state.yRange.size() > 0)
+    {
+        state.valid = true;
+    }
+}
+
+void PlotManager::handleBeforeReplot()
+{
+    if (m_currentPlotType == PlotType::Smith)
+        enforceSmithAspectRatio();
 }
 
 void PlotManager::setupSmithGrid()

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -49,8 +49,17 @@ public slots:
     bool removeSelectedMathPlots();
     void selectionChanged();
     void keepAspectRatio();
+    void handleAxisRangeChanged(const QCPRange &newRange);
+    void handleBeforeReplot();
 
 private:
+    struct AxisState
+    {
+        bool valid = false;
+        QCPRange xRange;
+        QCPRange yRange;
+    };
+
     enum class DragMode { None, Vertical, Horizontal, Curve };
     QCPAbstractPlottable* plot(const QVector<double> &x, const QVector<double> &y, const QPen &pen,
               const QString &name, Network* network, PlotType type, const QString &parameterKey = QString());
@@ -82,6 +91,9 @@ private:
     void setSmithMarkerFrequency(QCPItemTracer *tracer, double frequency);
     QString markerLabelText(const QString &markerName) const;
     double currentTickStep(const QCPAxis *axis) const;
+    void storeAxisState(PlotType type);
+    bool applyStoredAxisState(PlotType type);
+    void enforceSmithAspectRatio();
 
 
     QCustomPlot* m_plot;
@@ -107,6 +119,9 @@ private:
     bool m_crosshairEnabled;
     bool m_showPlotSettingsOnRightRelease;
     QPoint m_rightClickPressPos;
+
+    bool m_restoringAxisState;
+    QMap<PlotType, AxisState> m_axisStates;
 
     Qt::PenStyle m_gridPenStyle;
     QColor m_gridColor;


### PR DESCRIPTION
## Summary
- store per-plot axis ranges and restore them when switching plot types
- enforce smith chart aspect ratio on view changes/resizes and trigger immediate marker redraws
- default the crosshair cursor option to off

## Testing
- not run (Qt GUI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e579ef9c348326924abe3f691f00f2