### PR TITLE
Support cascading multiport networks

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -109,6 +109,7 @@ private:
     int adjustTableViewToContents(QTableView* view);
     void populateLumpedNetworkTable();
     void configureLumpedAndCascadeColumns(int parameterCount);
+    void appendPortItems(QList<QStandardItem*>& row, int toPort, int fromPort, bool editable);
     void appendParameterItems(QList<QStandardItem*>& row, Network* network);
     bool isParameterValueColumn(int column) const;
     int parameterIndexFromColumn(int column) const;

--- a/networkcascade.h
+++ b/networkcascade.h
@@ -27,6 +27,11 @@ public:
     QVector<double> frequencies() const override;
     int portCount() const override;
 
+    void setNetworkPortSelection(int index, int toPort, int fromPort);
+    int toPort(int index) const;
+    int fromPort(int index) const;
+    QPair<int, int> networkPortSelection(int index) const;
+
     void setFrequencyRange(double fmin, double fmax, bool manualOverride = true);
     void clearManualFrequencyRange();
     bool hasManualFrequencyRange() const;
@@ -38,6 +43,8 @@ private:
     void updateFrequencyRange();
 
     QList<Network*> m_networks;
+    QList<int> m_toPorts;
+    QList<int> m_fromPorts;
     int m_pointCount;
     bool m_manualFrequencyRange;
 };

--- a/networkfile.cpp
+++ b/networkfile.cpp
@@ -218,17 +218,20 @@ Eigen::MatrixXcd NetworkFile::sparameters(const Eigen::VectorXd& freq) const
     }
 
     const int ports = m_data->ports;
-    if (ports != 2) {
+    if (ports <= 0) {
         return {};
     }
 
-    Eigen::MatrixXcd s_matrix(freq.size(), 4);
+    const Eigen::Index expectedCols = static_cast<Eigen::Index>(ports) * static_cast<Eigen::Index>(ports);
+    if (m_data->sparams.cols() < expectedCols) {
+        return {};
+    }
+
+    Eigen::MatrixXcd s_matrix(freq.size(), expectedCols);
     for (int i = 0; i < freq.size(); ++i) {
-        std::complex<double> s11 = interpolate_s_param(freq(i), 0);
-        std::complex<double> s12 = interpolate_s_param(freq(i), 1);
-        std::complex<double> s21 = interpolate_s_param(freq(i), 2);
-        std::complex<double> s22 = interpolate_s_param(freq(i), 3);
-        s_matrix.row(i) << s11, s12, s21, s22;
+        for (Eigen::Index col = 0; col < expectedCols; ++col) {
+            s_matrix(i, col) = interpolate_s_param(freq(i), static_cast<int>(col));
+        }
     }
 
     return s_matrix;

--- a/networklumped.cpp
+++ b/networklumped.cpp
@@ -251,8 +251,8 @@ Eigen::MatrixXcd NetworkLumped::sparameters(const Eigen::VectorXd& freq) const
         }
 
         Eigen::Matrix2cd scattering = abcdToSParameterMatrix(abcd_point);
-        scattering_matrix.row(i) << scattering(0, 0), scattering(0, 1),
-                                    scattering(1, 0), scattering(1, 1);
+        scattering_matrix.row(i) << scattering(0, 0), scattering(1, 0),
+                                    scattering(0, 1), scattering(1, 1);
     }
 
     return scattering_matrix;


### PR DESCRIPTION
## Summary
- add “To”/“From” cascade columns in the UI and propagate edits into network selections
- extend NetworkCascade to remember per-stage port selections and slice multiport S-parameters consistently
- normalize S-parameter column ordering across sources and expand cascade tests for multiport and flipped orientations

## Testing
- ./test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e57eef304083268c9a7318cb405d1c