### PR TITLE
Preserve TDR marker positions across plot switches

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -206,6 +206,12 @@ g++ -std=c++17 -I/usr/include/eigen3 -I. \
     -o plotmanager_mathplot_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)
 
 g++ -std=c++17 -I/usr/include/eigen3 -I. \
+    tests/plotmanager_tdr_marker_tests.cpp plotmanager.cpp plotsettingsdialog.cpp network.cpp networklumped.cpp \
+    networkcascade.cpp parser_touchstone.cpp qcustomplot.cpp tdrcalculator.cpp \
+    moc_plotmanager.cpp moc_plotsettingsdialog.cpp moc_network.cpp moc_networklumped.cpp moc_networkcascade.cpp moc_qcustomplot.cpp \
+    -o plotmanager_tdr_marker_tests $(pkg-config --cflags --libs Qt6Widgets Qt6Gui Qt6Core Qt6PrintSupport)
+
+g++ -std=c++17 -I/usr/include/eigen3 -I. \
     tests/cascade_wheel_tests.cpp mainwindow.cpp networkitemmodel.cpp plotmanager.cpp plotsettingsdialog.cpp \
     parameterstyledialog.cpp network.cpp networkfile.cpp networklumped.cpp networkcascade.cpp parser_touchstone.cpp \
     qcustomplot.cpp tdrcalculator.cpp server.cpp cascadeio.cpp \

--- a/plotmanager.h
+++ b/plotmanager.h
@@ -89,6 +89,7 @@ private:
     void setMarkerValue(QCPItemTracer *tracer, double value);
     void setCartesianMarkerValue(QCPItemTracer *tracer, double value);
     void setSmithMarkerFrequency(QCPItemTracer *tracer, double frequency);
+    void storeMarkerValue(QCPItemTracer *tracer, double value);
     QString markerLabelText(const QString &markerName) const;
     double currentTickStep(const QCPAxis *axis) const;
     void storeAxisState(PlotType type);
@@ -114,6 +115,8 @@ private:
     QMap<QCPCurve*, QVector<double>> m_curveFreqs;
     QMap<QCPItemTracer*, QCPCurve*> m_tracerCurves;
     QMap<QCPItemTracer*, int> m_tracerIndices;
+    QMap<PlotType, double> m_tracerStoredKeysA;
+    QMap<PlotType, double> m_tracerStoredKeysB;
     bool m_keepAspectConnected;
     PlotType m_currentPlotType;
     bool m_crosshairEnabled;

--- a/test.sh
+++ b/test.sh
@@ -63,6 +63,7 @@ QT_QPA_PLATFORM=offscreen ./gui_plot_tests
 QT_QPA_PLATFORM=offscreen ./parameter_style_dialog_tests
 QT_QPA_PLATFORM=offscreen ./plotmanager_selection_tests
 QT_QPA_PLATFORM=offscreen ./plotmanager_mathplot_tests
+QT_QPA_PLATFORM=offscreen ./plotmanager_tdr_marker_tests
 QT_QPA_PLATFORM=offscreen ./cascade_wheel_tests
 QT_QPA_PLATFORM=offscreen ./plotsettingsdialog_tests
 

--- a/tests/plotmanager_tdr_marker_tests.cpp
+++ b/tests/plotmanager_tdr_marker_tests.cpp
@@ -1,0 +1,154 @@
+#include <QApplication>
+#include "plotmanager.h"
+#include "plotsettingsdialog.h"
+#include "qcustomplot.h"
+#include "network.h"
+
+#include <iostream>
+#include <cmath>
+
+class MarkerTestNetwork : public Network
+{
+public:
+    MarkerTestNetwork()
+        : Network(nullptr)
+    {
+        setVisible(true);
+        setColor(Qt::yellow);
+    }
+
+    QString name() const override { return QStringLiteral("marker_net"); }
+
+    Eigen::MatrixXcd sparameters(const Eigen::VectorXd& freq) const override
+    {
+        Q_UNUSED(freq);
+        return Eigen::MatrixXcd::Zero(1, 1);
+    }
+
+    QPair<QVector<double>, QVector<double>> getPlotData(int s_param_idx, PlotType type) override
+    {
+        if (s_param_idx != 0)
+            return {};
+
+        switch (type)
+        {
+        case PlotType::Magnitude:
+            return {QVector<double>{1.0, 2.0, 3.0}, QVector<double>{0.0, 1.0, 2.0}};
+        case PlotType::TDR:
+            return {QVector<double>{0.0, 0.5, 1.0}, QVector<double>{40.0, 45.0, 50.0}};
+        default:
+            return {};
+        }
+    }
+
+    Network* clone(QObject* parent = nullptr) const override
+    {
+        auto* copy = new MarkerTestNetwork();
+        copy->setParent(parent);
+        copy->setColor(color());
+        copy->setVisible(isVisible());
+        copy->setUnwrapPhase(unwrapPhase());
+        copy->setActive(isActive());
+        copy->setFmin(fmin());
+        copy->setFmax(fmax());
+        copy->copyStyleSettingsFrom(this);
+        return copy;
+    }
+
+    QVector<double> frequencies() const override
+    {
+        return QVector<double>{1.0, 2.0, 3.0};
+    }
+
+    int portCount() const override
+    {
+        return 1;
+    }
+};
+
+static QCPItemTracer* firstTracer(QCustomPlot &plot)
+{
+    for (int i = 0; i < plot.itemCount(); ++i)
+    {
+        if (auto *tracer = qobject_cast<QCPItemTracer*>(plot.item(i)))
+            return tracer;
+    }
+    return nullptr;
+}
+
+int main(int argc, char **argv)
+{
+    qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
+    QApplication app(argc, argv);
+
+    QCustomPlot plot;
+    PlotManager manager(&plot);
+
+    MarkerTestNetwork network;
+    QList<Network*> networks{&network};
+    manager.setNetworks(networks);
+    manager.setCascade(nullptr);
+
+    const QStringList sparams{QStringLiteral("s11")};
+
+    manager.updatePlots(sparams, PlotType::Magnitude);
+    manager.setCursorAVisible(true);
+
+    QCPItemTracer *tracerA = firstTracer(plot);
+    if (!tracerA)
+    {
+        std::cerr << "Failed to locate tracer A" << std::endl;
+        return 1;
+    }
+
+    if (!tracerA->graph())
+    {
+        std::cerr << "Tracer A had no graph in magnitude plot" << std::endl;
+        return 1;
+    }
+
+    tracerA->setGraphKey(2.0);
+
+    manager.updatePlots(sparams, PlotType::TDR);
+
+    if (!tracerA->graph())
+    {
+        std::cerr << "Tracer A had no graph in TDR plot" << std::endl;
+        return 1;
+    }
+
+    tracerA->setGraphKey(0.5);
+
+    manager.updatePlots(sparams, PlotType::Magnitude);
+
+    if (!tracerA->graph())
+    {
+        std::cerr << "Tracer A lost graph when returning to magnitude" << std::endl;
+        return 1;
+    }
+
+    double magnitudeKey = tracerA->graphKey();
+    if (std::abs(magnitudeKey - 2.0) > 1e-6)
+    {
+        std::cerr << "Magnitude marker key expected 2.0 but got " << magnitudeKey << std::endl;
+        return 1;
+    }
+
+    manager.updatePlots(sparams, PlotType::TDR);
+
+    if (!tracerA->graph())
+    {
+        std::cerr << "Tracer A lost graph when returning to TDR" << std::endl;
+        return 1;
+    }
+
+    double tdrKey = tracerA->graphKey();
+    if (std::abs(tdrKey - 0.5) > 1e-6)
+    {
+        std::cerr << "TDR marker key expected 0.5 but got " << tdrKey << std::endl;
+        return 1;
+    }
+
+    std::cout << "TDR marker persistence test passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- retain marker positions per plot type so TDR cursors restore correctly and show distance units
- centralize marker value storage, clearing when cursors hide and updating after moves
- add a plotmanager TDR marker regression test and wire it into build/test scripts

## Testing
- QT_QPA_PLATFORM=offscreen ./plotmanager_tdr_marker_tests

------
https://chatgpt.com/codex/tasks/task_e_68f92cf570dc8326bc5d20482dfa0fb1